### PR TITLE
Recreate implementation of Darakah/obsidian-timelines#20

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,11 @@ For statically generated timelines, events that occur at the same time are group
 
 Note: Currently only assets specified via `http` or `absolute local path` will render. Obsidian release `v0.10.13` blocked obsidian links for background images. 
 
+#### Era (`data-era`):
+  - Optional
+  - Adds this text to the date span in the timeline as an era designation. Useful for fictional calendars.
+  - Applied after the date is formatted. So `2300-00-00-00` with the era set to `AB` would display `2300 AB`.
+
 #### CSS Class (`data-class`):
   - Optional
   - Adds the applied css class to the note card associated with the timeline entry
@@ -214,24 +219,26 @@ Note: Acceptable values for `data-type` are:
   - `point`, which is exactly what it sounds like, and
   - `range`
 
+#### Path (`data-path`):
+  - Optional
+  - An alternate path to link the title to (excluding `[[` and `]]`). Default to the note the event is defined in, but you can use this to specify other notes or link to headers or blocks internally within the note. For example, `data-path='My Note#Event Subhead'` would link directly to the `Event Subhead` header in `My Note`
+  - If you use the "Page preview" plugin, this contents of this header will display when hovering over the title. Useful for quickly viewing expanded details without leaving the current timeline.
+
 ## Release Notes
 
-### v1.0.1
-Added more colors to the horizontal timeline!
+### v1.1.0
+Merged PR from upstream repository - `Added 'Era' suffix; Remove '.md' from titles; Enable alternative path` [#20](https://github.com/Darakah/obsidian-timelines/pull/20)
 
-More technical stuff:
-- refactored styling to use SCSS instead of CSS
-- created a mixin / function combo that will allow me to easily add support for new colors in the future.
-- added functionality to use color on background style events.
-- replaced the asset in the README with an updated version that shows off the new colors we can use.
+His notes about the change:
+> - Added optional span attribute 'era', allowing an era suffix to be displayed on the timeline.
+> - Removes the `.md` extension when auto-filling the title
+> - Ability to specify an alternative path to link the event to.
 
-### v1.0.0 (legacy v0.3.3)
-- refactored most of the plugin. 
-  - Introduced additional type checking and assertions. 
-  - Broke up functionality into smaller functions for better readability and maintenance.
-- updated readme to include better examples and instructions for creating and rendering a timeline.
-- audited and updated package dependencies for security vulnerabilities
-- updated to latest obsidian package
+Additional notes:
+- updated README to cover new changes to data attributes
+- created new changelog file for historical records of release notes
+
+See the [changelog](./changelog.md) for more details on previous releases.
 
 ## License
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,32 @@
+## Changelog
+
+### v1.0.2
+Added 2 new ways to insert events.
+
+- add new settings and command
+  - new command: "Insert Timeline Event" - inserts an empty timeline [div/span] at current mouse position in current note.
+  - new ribbon button for "Insert Timeline Event" command
+  - new setting: show/hide Ribbon button
+  - new setting: default HTML tag for creating new events
+
+More technical stuff:
+- set up workflows and protection for the `main` branch
+- created build and version scripts
+- add NPM commands for easy bumping versions (patch/minor/major)
+
+### v1.0.1
+Added more colors to the horizontal timeline!
+
+More technical stuff:
+- refactored styling to use SCSS instead of CSS
+- created a mixin / function combo that will allow me to easily add support for new colors in the future.
+- added functionality to use color on background style events.
+- replaced the asset in the README with an updated version that shows off the new colors we can use.
+
+### v1.0.0 (legacy v0.3.3)
+- refactored most of the plugin. 
+  - Introduced additional type checking and assertions. 
+  - Broke up functionality into smaller functions for better readability and maintenance.
+- updated readme to include better examples and instructions for creating and rendering a timeline.
+- audited and updated package dependencies for security vulnerabilities
+- updated to latest obsidian package

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "timelines-revamped",
   "name": "Timelines (Revamped)",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "minAppVersion": "0.10.11",
   "description": "Generate a chronological timeline in which all 'events' are notes that include a specific tag or set of tags.",
   "author": "seanlowe",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "timelines-revamped",
-    "version": "1.0.2",
+    "version": "1.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "timelines-revamped",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "license": "MIT",
             "dependencies": {
                 "rollup-plugin-styles": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "timelines-revamped",
-    "version": "1.0.2",
+    "version": "1.1.0",
     "description": "Generate a chronological timeline in which all 'events' are notes that include a specific tag or set of tags.",
     "main": "main.js",
     "scripts": {

--- a/src/block.ts
+++ b/src/block.ts
@@ -81,6 +81,7 @@ export class TimelineProcessor {
     newEventElement.setAttribute( 'data-start-date', '' )
     newEventElement.setAttribute( 'data-end-date', '' )
     newEventElement.setAttribute( 'data-era', '' )
+    newEventElement.setAttribute( 'data-path', '' )
     newEventElement.setText( 'New Event' )
 
     // add a newline and a tab after each data attribute

--- a/src/block.ts
+++ b/src/block.ts
@@ -74,12 +74,13 @@ export class TimelineProcessor {
     // create a div element with the correct data attributes
     const newEventElement = document.createElement( this.settings.eventElement )
     newEventElement.setAttribute( 'class', 'ob-timelines' )
-    newEventElement.setAttribute( 'data-start-date', '' )
     newEventElement.setAttribute( 'data-title', '' )
-    newEventElement.setAttribute( 'data-class', '' )
     newEventElement.setAttribute( 'data-description', '' )
+    newEventElement.setAttribute( 'data-class', '' )
     newEventElement.setAttribute( 'data-type', '' )
+    newEventElement.setAttribute( 'data-start-date', '' )
     newEventElement.setAttribute( 'data-end-date', '' )
+    newEventElement.setAttribute( 'data-era', '' )
     newEventElement.setText( 'New Event' )
 
     // add a newline and a tab after each data attribute
@@ -144,14 +145,16 @@ export class TimelineProcessor {
           dataset: {
             startDate,
             // if no title is specified, use the note's name
-            title: noteTitle = file.name,
+            title: noteTitle = file.name.replace( '.md', '' ),
             class: noteClass = '',
             type = 'box',
             endDate = null,
-            img: eventImg = null
+            img: eventImg = null,
+            path,
+            era,
           }
         } = event
-        const notePath = '/' + file.path
+        const notePath = path ?? '/' + file.path
 
         // check if a valid date is specified
         const noteId = ( startDate[0] === '-' )
@@ -168,7 +171,8 @@ export class TimelineProcessor {
           path: notePath,
           class: noteClass,
           type,
-          endDate
+          endDate,
+          era,
         }
 
         if ( !timelineNotes[noteId] ) {
@@ -227,10 +231,11 @@ export class TimelineProcessor {
         cls: 'timeline-event-list',
         attr: { 'style': 'display: block' }
       })
-      const noteHeader = noteContainer.createEl( 'h2', {
-        text: timelineNotes[date][0].startDate
-          .replace( /-0*$/g, '' ).replace( /-0*$/g, '' ).replace( /-0*$/g, '' )
-      })
+      let dateText = timelineNotes[date][0].startDate.replace( /-0*$/g, '' ).replace( /-0*$/g, '' ).replace( /-0*$/g, '' )
+      if ( timelineNotes[date][0].era ) {
+        dateText += ` ${timelineNotes[date][0].era}`
+      }
+      const noteHeader = noteContainer.createEl( 'h2', { text: dateText })
 
       noteContainer.addEventListener( 'click', ( event ) => {
         event.preventDefault()

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,8 @@ export interface CardContainer {
   path: string,
   endDate: string,
   type: string,
-  class: string
+  class: string,
+  era: string
 }
 
 export interface EventItem {


### PR DESCRIPTION
Recreates implementation of Darakah/obsidian-timelines#20

Credit to @tlm2021 for his work on the original PR. Tweaked to work on the refactors I did on the codebase but code is basically the same.

Also updated the "Insert Timeline Event" to add the `data-era` and `data-path` attributes to the template event it generates.