### PR TITLE
Some more small publishing changes

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
-The MIT License (MIT)
+MIT License
 
-Copyright (c) 2014 SINTEF-9012
+Copyright (c) 2023 Sean Lowe
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Also kudos to everyone who contributed to the original plugin, especially:
 - [Erin Schnabel](https://github.com/ebullient),
 - [ReconVirus](https://github.com/ReconVirus),
 - [Ethan Miller](https://github.com/ethanimproving), and
-- [tlm2021](https://github.com/tlm2021)
+- [Travis Mosley](https://github.com/tlm2021)
 
 <br>
 
@@ -34,10 +34,11 @@ Generate a chronological timeline in which all "events" are notes that include a
 See the changelog from the last major update to view any breaking changes [here](./changelog.md#v200).
 
 ## Examples
-<img src="./images/horizontal_example.png" align="left">
-<img src="./images/vertical_example.png" align="right">
+<img src="./images/horizontal_example.png" align="center">
+<br>
+<img src="./images/vertical_example.png" align="center">
 
-<h2 style="padding-top: 525px"> Inserting a Timeline </h2>
+## Inserting a Timeline
 
 Rendering a timeline requires a couple *separate* pieces, the main two are:
 1. "events" within a note, which can be specified by:
@@ -66,6 +67,10 @@ Breaking down the filters:
 - `maxDate`: maximum end-cap to prevent scrolling or viewing after this date
 - `type`: horizontal-specific key. Pass `flat` in order to render a horizontal timeline.
 
+<br>
+
+> **Note:** the codeblock uses the key `ob-timeline` so that there is no conflict with other timeline plugins, specifically George-debug's Timeline [plugin](https://github.com/George-debug/obsidian-timeline).
+
 ### Using an HTML code block for static rendering
 
 Insert the following HTML comment where a statically rendered timeline should be inserted:
@@ -76,7 +81,7 @@ Insert the following HTML comment where a statically rendered timeline should be
 <!--TIMELINE END-->
 ```
 
-Use the `Timelines: Render Static Timeline` command to generate a static timeline. The command will generate static HTML and populate it between the HTML comments (BEGIN/END).
+Use the `Render static timeline` command to generate a static timeline. The command will generate static HTML and populate it between the HTML comments (BEGIN/END).
 
 Running the command again will replace everything in between the comments with a freshly rendered timeline.
 
@@ -112,7 +117,7 @@ When generating a timeline, a note will be ignored in the following cases:
 ## Timeline Event Properties
 
 Timeline events must specify the following: 
-- a valid date, YEAR-MONTH-DAY-MINUTES (check info section below for more details)
+- a valid date, YEAR-MONTH-DAY-HOUR (check info section below for more details)
 - a valid class, specifically `ob-timelines` must be specified.
 
 All other fields are optional.
@@ -171,9 +176,11 @@ A timeline entry can be created using a `<span></span>` or `<div></div>` HTML el
 There are multiple ways to insert an event. Of course, you can do it manually, but there also exist two additional ways to quickly insert an event into your note (at your current mouse position):
 
   1. Click the `</>` button on the ribbon
-  2. Open the command palette and run the `Insert Timeline Event`
+  2. Open the command palette and run the `Insert timeline event`.
 
 Both of these will insert a new event `div` or `span` (it uses whichever value you've set in Settings but defaults to `div`) with all `data-*` attributes present but empty. Delete what you don't need, fill in what you want. 
+
+> **Note:** There is also a ribbon icon and a command for inserting frontmatter into the current note.
 
 ### Customization
 
@@ -228,17 +235,17 @@ Rightmost-segments containing only zeros will be omitted when the timeline is ge
 
 Any included Month/Day sections of a date must be non-zero (for the time being) in order for the date to properly parse and be included on the timeline. 
 
-For example: `2300-02-00-00` should actually be passed in as: `2300-02` if you don't care about the day, or `2300-02-01` if you mean that it began at the beginning of the month. The last section of a date (the time), however, can be zero if you want.
+For example: `2300-02-00-00` should actually be passed in as: `2300-02` if you don't care about the day, or `2300-02-01` if you mean that it began at the beginning of the month. The last section of a date (the time), however, can be zero if you want. Any section that is not passed in will be added internally with the valid minimal value (`01` for months and days, and `00` for time.)
 
-As of right now, there is no kind of date normalization, as there are considerations that must be handled when dealing with fictional calendars. The side result of this is that, when comparing two events, an event with a start date of `2300-02-1-23` will be displayed before an event with a start date of `2300-02-01-04`, even though HOUR value on the first example is *after* the second (23 vs. 04).
+Date normalization is handled according to the next section **Event Sorting**, so that dates -- even fantasy ones -- are sorted in the order specified. Although, there are some ... *intricacies*, when dealing with odd fantasy dates with the horizontal timeline simply due to the library used to generate the timeline. I'm looking into better solutions for this.
 
 ##### Event Sorting
 
 Event sorting is performed by padding all sections of the date with leading zeros so that all sections are the same length. The resulting string is compared directly against other strings. The length to which sections will be padded is controlled by the `Maximum padding on dates` value in the settings tab.
 
 For example, for these two dates with a max padding value of `4`:
-- `2300-02-00-00` would be padded and sorted as ` 2300-0002-0000-0000`, whereas
-- `-234-02-00-00` would be padded and sorted as `-0234-0002-0000-0000`.
+- `2300-02-01-00` would be padded and sorted as ` 2300-0002-0001-0000`, whereas
+- `-234-02-01-00` would be padded and sorted as `-0234-0002-0001-0000`.
 
 We can now see how simple it is to have any kind of calendar you want (fantasy or otherwise) and have it sort the way you'd like. Any missing sections will be automatically populated for you, with missing months and day values being set to `01` and the time value being set to `00`.
 
@@ -293,14 +300,15 @@ Note: Acceptable values for `data-type` are:
 
 ## Release Notes
 
-### v2.1.2
+### v2.1.3
 
-Small tweaks to packages for better build quality (that was released in v2.1.1 but I forgot to make a changelog for that so here it is now).
+Some more small changes requested by the Obsidian staff in order to get the plugin published to the community list.
 
 **Changes:**
-- updated the Readme regarding date parsing change that happened in version [2.1.0](./changelog.md#v210)
-- added callouts to big contributors of the original plugin
-- added a notice to the top of the readme with a link to the changelog for version [2.0.0](./changelog.md#v200) since there were breaking changes in that update.
+- updated the titles of commands to be sentence-case
+- removed the toggle switch setting to show/hide ribbon icons. End users have the ability to individually toggle icons on their own, so there's no need for a setting for it.
+- updated the license name / year, still using the MIT License
+- updated callout at top of README to use tlm2021's name instead of his username along with some QOL updates to the README
 
 See the [changelog](./changelog.md) for more details on previous releases.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,14 @@
 ## Changelog
 
+### v2.1.2
+
+Small tweaks to packages for better build quality (that was released in v2.1.1 but I forgot to make a changelog for that so here it is now).
+
+**Changes:**
+- updated the Readme regarding date parsing change that happened in version [2.1.0](./changelog.md#v210)
+- added callouts to big contributors of the original plugin
+- added a notice to the top of the readme with a link to the changelog for version [2.0.0](./changelog.md#v200) since there were breaking changes in that update.
+
 ### v2.1.0
 
 Fairly sizeable changes in preparation for official publishing!

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "timelines-revamped",
   "name": "Timelines (Revamped)",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "minAppVersion": "0.10.11",
   "description": "Generate a chronological timeline in which all 'events' are notes that include a specific tag or set of tags.",
   "author": "seanlowe",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "timelines-revamped",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "timelines-revamped",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT",
       "dependencies": {
         "rollup-plugin-styles": ">=4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timelines-revamped",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Generate a chronological timeline in which all 'events' are notes that include a specific tag or set of tags.",
   "main": "main.js",
   "scripts": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,7 +11,6 @@ export const DEFAULT_SETTINGS: TimelinesSettings = {
   frontMatterKeys: DEFAULT_FRONTMATTER_KEYS,
   notePreviewOnHover: true,
   showEventCounter: false,
-  showRibbonCommands: false,
   sortDirection: true,
   timelineTag: 'timeline',
   maxDigits: '5',

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ import { TimelineCommandProcessor } from './commands'
 import { logger } from './utils'
 
 export default class TimelinesPlugin extends Plugin {
-  pluginName: string = 'Timelines (Revamped)'
+  pluginName: string = this.manifest.name
   settings: TimelinesSettings
   statusBarItem: HTMLElement
   blocks: TimelineBlockProcessor
@@ -34,7 +34,7 @@ export default class TimelinesPlugin extends Plugin {
 
     this.addCommand({
       id: 'render-static-timeline',
-      name: 'Render Static Timeline',
+      name: 'Render static timeline',
       checkCallback: ( checking: boolean ) => {
         const markdownView = this.app.workspace.getActiveViewOfType( MarkdownView )
         if ( markdownView ) {
@@ -51,7 +51,7 @@ export default class TimelinesPlugin extends Plugin {
 
     this.addCommand({
       id: 'insert-timeline-event',
-      name: 'Insert Timeline Event',
+      name: 'Insert timeline event',
       checkCallback: ( checking: boolean ) => {
         const markdownView = this.app.workspace.getActiveViewOfType( MarkdownView )
         if ( markdownView ) {
@@ -66,7 +66,7 @@ export default class TimelinesPlugin extends Plugin {
 
     this.addCommand({
       id: 'insert-timeline-event-frontmatter',
-      name: 'Insert Timeline Event (Frontmatter)',
+      name: 'Insert timeline event (frontmatter)',
       checkCallback: ( checking: boolean ) => {
         const markdownView = this.app.workspace.getActiveViewOfType( MarkdownView )
         if ( markdownView ) {
@@ -81,17 +81,13 @@ export default class TimelinesPlugin extends Plugin {
 
     this.addSettingTab( new TimelinesSettingTab( this.app, this ))
 
-    /* --- setting specific checks --- */
+    this.addRibbonIcon( 'code-2', 'Insert Timeline Event', async () => {
+      await this.commands.createTimelineEventInCurrentNote()
+    })
 
-    if ( this.settings.showRibbonCommands ) {
-      this.addRibbonIcon( 'code-2', 'Insert Timeline Event', async () => {
-        await this.commands.createTimelineEventInCurrentNote()
-      })
-
-      this.addRibbonIcon( 'list-plus', 'Insert Timeline Event (Frontmatter)', async () => {
-        await this.commands.createTimelineEventFrontMatterInCurrentNote()
-      })
-    }
+    this.addRibbonIcon( 'list-plus', 'Insert Timeline Event (Frontmatter)', async () => {
+      await this.commands.createTimelineEventFrontMatterInCurrentNote()
+    })
 
     if ( this.settings.showEventCounter ) {
       this.commands.createStatusBar( this )

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -70,24 +70,6 @@ export class TimelinesSettingTab extends PluginSettingTab {
           })
       })
 
-    const fragment = document.createDocumentFragment()
-    const div = document.createElement( 'div' )
-    div.innerText = `Default: on. Turn this setting on to show a button on the ribbon to quickly insert new events.
-      NOTE: Requires an app restart for changes to take effect.
-    `
-    fragment.appendChild( div )
-
-    new Setting( containerEl )
-      .setName( 'Show ribbon buttons' )
-      .setDesc( fragment )
-      .addToggle(( toggle ) => {
-        toggle.setValue( this.plugin.settings.showRibbonCommands )
-        toggle.onChange( async ( value: boolean ) => {
-          this.plugin.settings.showRibbonCommands = value
-          await this.plugin.saveSettings()
-        })
-      })
-
     new Setting( containerEl )
       .setName( 'Show event counter' )
       .setDesc(

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,7 +79,6 @@ export interface TimelinesSettings {
   frontMatterKeys: FrontMatterKeys,
   notePreviewOnHover: boolean,
   showEventCounter: boolean,
-  showRibbonCommands: boolean,
   sortDirection: boolean,
   timelineTag: string,
   maxDigits: string,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -143,8 +143,8 @@ export const normalizeDate = ( date: string, maxDigits: number ): string => {
   // cases:
   // 4 sections: YYYY-MM-DD-HH (perfect, send it off as is)
   // 3 sections: YYYY-MM-DD (add 00 at the end)
-  // 2 sections: YYYY-MM (add 00-00 at the end)
-  // 1 section: YYYY (add 00-00-00 at the end)
+  // 2 sections: YYYY-MM (add 01-00 at the end)
+  // 1 section: YYYY (add 01-01-00 at the end)
 
   switch ( sections.length ) {
   case 1:


### PR DESCRIPTION
Some more small changes requested by the Obsidian staff in order to get the plugin published to the community list.

**Changes:**
- updated the titles of commands to be sentence-case
- removed the toggle switch setting to show/hide ribbon icons. End users have the ability to individually toggle icons on their own, so there's no need for a setting for it.
- updated the license name / year, still using the MIT License
- updated callout at top of README to use tlm2021's name instead of his username along with some QOL updates to the README