### PR TITLE
revamp node color functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,9 +287,10 @@ Note: Currently only assets specified via `http` or `absolute local path` will r
 
 #### Node Color (`data-color`):
   - Optional
-  - Adds the color specified as a CSS class on the appropriate HTML elements in order to be associated with that timeline entry.
+  - Tells the timeline to color that entry in the color provided.
+  - Supports hex color codes and color names, such as `blue`, `red`, `rebeccapurple`, `#96F613`, or `FF7F50`
 
-Note: Acceptable values for `data-color` are `orange`, `yellow`, `red`, `blue`, `green`, `purple`, `pink`, and `gray`. If the value is not supplied, events will be colored white (or gray for background events) on the timeline.
+Note: If a value is not supplied, events will be colored `white` (or `gray` for background events) on the timeline.
 
 #### Type (`data-type`):
   - Optional
@@ -313,16 +314,15 @@ Note: Acceptable values for `data-type` are:
 
 ## Release Notes
 
-### v2.1.4
+### v2.1.5
 
-Added support for changing the maximum and minimum zoom levels on the horizontal timeline.
+Revamped event color functionality.
 
 **Changes:**
-- renamed `TimelineArgs` to `InternalTimelineArgs` and updated to be more specific for each possible argument.
-- added support for `zoomInLimit` and `zoomOutLimit`
-- updated the README with information on how to use the new arguments
-- updated the horizontal codeblock example image with the new arguments
-- extracted some logic dealing with arguments from `utils/index.ts` to its own file
+- added support to pass essentially any color as a value in the color field on events (HTML or Frontmatter)
+- updated the `Node Color` section in the README to cover the new functionality
+- wrote functions to handle dynamically adding the stylesheets for custom colors in `utils/colors.ts`
+- added function to `block.ts` to handle whether or not the color provided was one of the built-ins or if it requires the dynamic logic
 
 See the [changelog](./changelog.md) for more details on previous releases.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,16 @@
 ## Changelog
 
+### v2.1.4
+
+Added support for changing the maximum and minimum zoom levels on the horizontal timeline.
+
+**Changes:**
+- renamed `TimelineArgs` to `InternalTimelineArgs` and updated to be more specific for each possible argument.
+- added support for `zoomInLimit` and `zoomOutLimit`
+- updated the README with information on how to use the new arguments
+- updated the horizontal codeblock example image with the new arguments
+- extracted some logic dealing with arguments from `utils/index.ts` to its own file
+
 ### v2.1.3
 
 Some more small changes requested by the Obsidian staff in order to get the plugin published to the community list.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "timelines-revamped",
   "name": "Timelines (Revamped)",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "minAppVersion": "0.10.11",
   "description": "Generate a chronological timeline in which all 'events' are notes that include a specific tag or set of tags.",
   "author": "seanlowe",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "timelines-revamped",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "timelines-revamped",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "license": "MIT",
       "dependencies": {
+        "chroma-js": "^2.4.2",
         "lodash": "^4.17.21",
         "rollup-plugin-styles": ">=4.0.0",
         "vis-timeline": ">=7.7.2"
@@ -17,6 +18,7 @@
         "@rollup/plugin-commonjs": ">=15.1.0",
         "@rollup/plugin-node-resolve": ">=9.0.0",
         "@rollup/plugin-typescript": ">=6.1.0",
+        "@types/chroma-js": "^2.4.4",
         "@types/lodash": "^4.17.0",
         "@types/node": ">=14.18.54",
         "@typescript-eslint/eslint-plugin": ">=6.2.1",
@@ -465,6 +467,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/@types/chroma-js": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/chroma-js/-/chroma-js-2.4.4.tgz",
+      "integrity": "sha512-/DTccpHTaKomqussrn+ciEvfW4k6NAHzNzs/sts1TCqg333qNxOhy8TNIoQCmbGG3Tl8KdEhkGAssb1n3mTXiQ==",
+      "dev": true
     },
     "node_modules/@types/codemirror": {
       "version": "5.60.8",
@@ -1004,6 +1012,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/chroma-js": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.4.2.tgz",
+      "integrity": "sha512-U9eDw6+wt7V8z5NncY2jJfZa+hUH8XEj8FQHgFJTrUFnJfXYf4Ml4adI2vXZOjqRDpFWtYVWypDfZwnJ+HIR4A=="
     },
     "node_modules/color-convert": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timelines-revamped",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Generate a chronological timeline in which all 'events' are notes that include a specific tag or set of tags.",
   "main": "main.js",
   "scripts": {
@@ -18,6 +18,7 @@
     "@rollup/plugin-commonjs": ">=15.1.0",
     "@rollup/plugin-node-resolve": ">=9.0.0",
     "@rollup/plugin-typescript": ">=6.1.0",
+    "@types/chroma-js": "^2.4.4",
     "@types/lodash": "^4.17.0",
     "@types/node": ">=14.18.54",
     "@typescript-eslint/eslint-plugin": ">=6.2.1",
@@ -30,6 +31,7 @@
     "typescript": ">=5.1.6"
   },
   "dependencies": {
+    "chroma-js": "^2.4.2",
     "lodash": "^4.17.21",
     "rollup-plugin-styles": ">=4.0.0",
     "vis-timeline": ">=7.7.2"

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ export interface InternalTimelineArgs {
 }
 
 export interface CardContainer {
+  id: string,
   color: string,
   endDate: string,
   era: string,

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -1,0 +1,58 @@
+import chroma, { type Color, valid } from 'chroma-js'
+
+export const availableColors = ['orange', 'blue', 'green', 'red', 'purple', 'yellow', 'pink', 'gray']
+const types = [ 'vis-background', 'vis-box', 'vis-point', 'vis-range', 'vis-line', 'vis-dot' ]
+// STOP - did you remember to change the matching variables in horizontal-timeline.scss?
+
+type AddColorInput = {
+  color: Color,
+  selector: string,
+  addon?: string,
+  alpha?: number
+}
+
+const lightenBackground = ( color: Color, alpha: number = .3 ): string => {
+  return color.brighten( .2 ).alpha( alpha ).hex()
+}
+
+const addColor = (
+  {
+    color,
+    selector: startingElement,
+    addon = '',
+    alpha = .3
+  }: AddColorInput,
+  customClassName: string,
+): string => {
+  const lightenedBackground = lightenBackground( color, alpha )
+  const selector = `${startingElement}.${customClassName}${addon}`
+  const block = `{ filter: none; background-color: ${lightenedBackground}; border-color: ${color}; }\n`
+  return `${selector} ${block}`
+}
+
+export const handleDynamicColor = ( color: string, noteId: string ) => {
+  if ( !valid( color )) {
+    throw new Error( `Invalid color: ${color}` )
+  }
+  const colorObject = chroma( color )
+  const id = `nid-${noteId}`
+
+  // add all the various parts that need coloring
+  const newRules: string[] = []
+  for ( const type of types ) {
+    newRules.push( addColor({ color: colorObject, selector: '.vis-item' }, id ))
+    newRules.push( addColor({ color: colorObject, selector: `.vis-item.${type}` }, id ))
+    newRules.push( addColor({ color: colorObject, selector: `.vis-item.${type}.vis-selected`, alpha: .45 }, id ))
+    newRules.push( addColor({ color: colorObject, selector: '.vis-item', addon: ':hover', alpha: .45 }, id ))
+  }
+  // STOP - did you remember to change the matching rules in horizontal-timeline.scss?
+
+  // grab the stylesheet with all the .vis-X class rules
+  // [0] is one with a bunch of .cm rules
+  // [1] is obsidian's big ass stylesheet (over 1700 rules)
+  // [2] is the one we want
+  const stylesheet = document.styleSheets[2]
+  for ( const rule of newRules ) {
+    stylesheet.insertRule( rule, stylesheet.cssRules.length )
+  }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -15,6 +15,7 @@ export * from './debug'
 export * from './events'
 export * from './frontmatter'
 export * from './arguments'
+export * from './colors'
 
 /**
  * Filter markdown files by tag

--- a/styles/horizontal-timeline.scss
+++ b/styles/horizontal-timeline.scss
@@ -2,6 +2,7 @@
 
 $available-colors: orange, blue, green, red, purple, yellow, pink, gray;
 $vis-item-types: 'vis-background', 'vis-box', 'vis-point', 'vis-range', 'vis-line', 'vis-dot';
+// STOP - did you remember to change the matching variables in colors.ts?
 
 .vis-timeline {
   border: 1px solid transparent;
@@ -44,6 +45,7 @@ div.vis-item-overflow > div > a {
     }
   }
 }
+// STOP - did you remember to change the matching rules in colors.ts?
 
 .vis-panel {
   &.vis-center,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,21 @@
 {
   "compilerOptions": {
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
     "baseUrl": ".",
+    "importHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
-    "module": "ESNext",
-    "target": "es6",
-    "allowJs": true,
-    // "noImplicitAny": true,
-    "moduleResolution": "node",
-    "importHelpers": true,
     "lib": [
       "dom",
       "es5",
       "scripthost",
       "es2015"
-    ]
+    ],
+    "module": "ESNext",
+    "moduleResolution": "node",
+    // "noImplicitAny": true,
+    "target": "es6",
   },
   "include": [
     "**/*.ts"


### PR DESCRIPTION
### v2.1.5

Revamped event color functionality.

**Changes:**
- added support to pass essentially any color as a value in the color field on events (HTML or Frontmatter)
- updated the `Node Color` section in the README to cover the new functionality
- wrote functions to handle dynamically adding the stylesheets for custom colors in `utils/colors.ts`
- added function to `block.ts` to handle whether or not the color provided was one of the built-ins or if it requires the dynamic logic

---

Resolves #32 and lays the groundwork for completing #14.