### PR TITLE
Add better highlighting for horizontal timeline events

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,13 +314,16 @@ Note: Acceptable values for `data-type` are:
 
 ## Release Notes
 
-### v2.1.6
+### v2.1.7
 
-Bug fix for Issue [seanlowe/obsidian-timelines#39](https://github.com/seanlowe/obsidian-timelines/issues/39)
+Implements issue [seanlowe/obsidian-timelines#34](https://github.com/seanlowe/obsidian-timelines/issues/34)
 
 **Changes:**
-- fixed incorrect rendering of events with hours specified. Hours will now shift the event as expected
-- fixed an issue where notes would not be added to the timeline due to tags not having `#` removed
+- added event listeners onto timeline events to run some logic when items are being hovered on
+  - adds a custom CSS class `.runtime-hover` on mouse enter, and removes it when the mouse leaves the event
+  - adds some logic to set a CSS variable with the particular event's background color
+- added styling rules for CSS class `.runtime-hover` that takes into account the current background color (that was pushed into a CSS variable by the event listeners)
+- allowed for timeline event objects to have a copy of the data from the user-created events (HTML/FM)
 
 See the [changelog](./changelog.md) for more details on previous releases.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 ## Changelog
 
+### v2.1.6
+
+Bug fix for Issue [seanlowe/obsidian-timelines#39](https://github.com/seanlowe/obsidian-timelines/issues/39)
+
+**Changes:**
+- fixed incorrect rendering of events with hours specified. Hours will now shift the event as expected
+- fixed an issue where notes would not be added to the timeline due to tags not having `#` removed
+
 ### v2.1.5
 
 Revamped event color functionality.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "timelines-revamped",
   "name": "Timelines (Revamped)",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "minAppVersion": "0.10.11",
   "description": "Generate a chronological timeline in which all 'events' are notes that include a specific tag or set of tags.",
   "author": "seanlowe",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "timelines-revamped",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "timelines-revamped",
-      "version": "2.1.6",
+      "version": "2.1.7",
       "license": "MIT",
       "dependencies": {
         "chroma-js": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timelines-revamped",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Generate a chronological timeline in which all 'events' are notes that include a specific tag or set of tags.",
   "main": "main.js",
   "scripts": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,7 @@ export interface EventItem {
   path: string,
   start: Date,
   type: string,
+  _event?: Partial<EventDataObject>,
 }
 
 export interface EventTypeNumbers {

--- a/styles/horizontal-timeline.scss
+++ b/styles/horizontal-timeline.scss
@@ -1,11 +1,21 @@
 @use './colors.scss' as *;
 
+:root {
+  hoverHighlightColor: transparent;
+}
+
 $available-colors: orange, blue, green, red, purple, yellow, pink, gray;
 $vis-item-types: 'vis-background', 'vis-box', 'vis-point', 'vis-range', 'vis-line', 'vis-dot';
 // STOP - did you remember to change the matching variables in colors.ts?
 
 .vis-timeline {
   border: 1px solid transparent;
+}
+
+.runtime-hover {
+  background: color-mix(in oklab, var(--hoverHighlightColor), transparent 40%);
+  border-color: color-mix(in oklab, var(--hoverHighlightColor), white 30%) !important;
+  filter: none;
 }
 
 .vis-item-content,


### PR DESCRIPTION
### Release: v2.1.7

**Changes:**
- added event listeners onto timeline events to run some logic when items are being hovered on
  - adds a custom CSS class `.runtime-hover` on mouse enter, and removes it when the mouse leaves the event
  - adds some logic to set a CSS variable with the particular event's background color
- added styling rules for CSS class `.runtime-hover` that takes into account the current background color (that was pushed into a CSS variable by the event listeners)
- allowed for timeline event objects to have a copy of the data from the user-created events (HTML/FM)

---

Resolves #34 