### PR TITLE
fix end/start/min/max date arguments in codeblocks not respecting nar…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,14 @@ I've written a brand new GitHub Pages docs site for **Timelines (Revamped)** at 
 
 ## Release Notes
 
-### v2.1.11
+### v2.1.12
 
-Fix issue: `No body in timeline event created via frontmatter` [#48](https://github.com/seanlowe/obsidian-timelines/issues/48)
+Fix issue: `Refined Horizontal Timeline View` [#49](https://github.com/seanlowe/obsidian-timelines/issues/49)
 
 **Changes**:
-- made it possible to specify the textual body of an event defined via frontmatter by way of the 'description' property
-- edited style rules so that whitespace within the description property (line breaks, esp.) is respected and not discarded
-- reinstated the 'description' property for HTML defined events (albeit redundant) 
-- updated documentation to reflect changes
+- removed incorrect function `createYearArgument` in favour of using `buildTimelineDate` everywhere a Date is needed
+- move `normalizeDate` and `buildTimelineDate` from `utils/index.ts` to own file `dates.ts` to avoid a circular dependency
+- updated docs with some extra info regarding this change
 
 See the [changelog](./changelog.md) for more details on previous releases.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,15 @@
 ## Changelog
 
+### v2.1.11
+
+Fix issue: `No body in timeline event created via frontmatter` [#48](https://github.com/seanlowe/obsidian-timelines/issues/48)
+
+**Changes**:
+- made it possible to specify the textual body of an event defined via frontmatter by way of the 'description' property
+- edited style rules so that whitespace within the description property (line breaks, esp.) is respected and not discarded
+- reinstated the 'description' property for HTML defined events (albeit redundant) 
+- updated documentation to reflect changes
+
 ### v2.1.10
 
 Maintenance update

--- a/docs/content/docs/01_guides/00_getting_started/02_adding_events.md
+++ b/docs/content/docs/01_guides/00_getting_started/02_adding_events.md
@@ -32,6 +32,7 @@ In our note, we should see something like this:
 ```html
 <div class="ob-timelines"
 	data-title=""
+	data-description=""
 	data-color=""
 	data-type=""
 	data-start-date=""

--- a/docs/content/docs/03_arguments/00_codeblock_arguments.md
+++ b/docs/content/docs/03_arguments/00_codeblock_arguments.md
@@ -22,6 +22,7 @@ Breaking down the filters:
 - `type`: horizontal-specific key. Pass `flat` in order to render a horizontal timeline
 
 Acceptable values for filters:
+- `startDate`, `endDate`, `minDate`, `maxDate`: use the same format (`YYYY-MM-DD-HH`) as event date parameters
 - `zoomInLimit`:
   - You can either use the built-in timescales, or you can provide a value (in milliseconds) manually. Acceptable values are `day`, `week`, `month-detail`, `month-vague`, and `year`. Do not include to have no restrictions on zooming in (default behaviour).
     - `day` zooms down to one day, but still shows hours

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "timelines-revamped",
   "name": "Timelines (Revamped)",
-  "version": "2.1.11",
+  "version": "2.1.12",
   "minAppVersion": "0.10.11",
   "description": "Generate a chronological timeline in which all 'events' are notes that include a specific tag or set of tags.",
   "author": "seanlowe",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "timelines-revamped",
-  "version": "2.1.11",
+  "version": "2.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "timelines-revamped",
-      "version": "2.1.11",
+      "version": "2.1.12",
       "license": "MIT",
       "dependencies": {
         "chroma-js": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timelines-revamped",
-  "version": "2.1.11",
+  "version": "2.1.12",
   "description": "Generate a chronological timeline in which all 'events' are notes that include a specific tag or set of tags.",
   "main": "main.js",
   "scripts": {

--- a/src/block.ts
+++ b/src/block.ts
@@ -5,7 +5,6 @@ import { RENDER_TIMELINE } from './constants'
 import {
   availableColors,
   buildTimelineDate,
-  createYearArgument,
   createInternalLinkOnNoteCard,
   createTagList,
   convertEntryToMilliseconds,
@@ -97,7 +96,7 @@ export class TimelineBlockProcessor {
 
       if ( tag.includes( 'Date' )) {
         // startDate, endDate, minDate, maxDate
-        const result = createYearArgument( value )
+        const result = buildTimelineDate( value )
         this.args[tag] = result
         return
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,11 +31,11 @@ export interface InternalTimelineArgs {
 
 export interface CardContainer {
   id: string,
+  body: string,
   color: string,
   endDate: string,
   era: string,
   img: string,
-  body: string,
   path: string,
   startDate: string,
   title: string,
@@ -47,9 +47,9 @@ export interface EventDataObject {
   endDate: string,
   era: string,
   eventImg: string,
+  noteBody: string,
   notePath: string,
   noteTitle: string,
-  noteBody: string,
   showOnTimeline: boolean | null,
   startDate: string,
   tags: string,

--- a/src/utils/arguments.ts
+++ b/src/utils/arguments.ts
@@ -1,14 +1,15 @@
 import { isNaN } from 'lodash'
 import { InternalTimelineArgs } from '../types'
+import { buildTimelineDate } from './dates'
 
 export function setDefaultArgs(): InternalTimelineArgs {
   return {
     tags: [] as string[],
     divHeight: 400,
-    startDate: createYearArgument( '-1000' ),
-    endDate: createYearArgument( '3000' ),
-    minDate: createYearArgument( '-3000' ),
-    maxDate: createYearArgument( '3000' ),
+    startDate: buildTimelineDate( '-1000' ),
+    endDate: buildTimelineDate( '3000' ),
+    minDate: buildTimelineDate( '-3000' ),
+    maxDate: buildTimelineDate( '3000' ),
     type: null,
 
     // have to put it to one more than the default max so that min actually works
@@ -49,18 +50,6 @@ export function parseTag( tag: string, tagList: string[] ): void {
     tag = tag.substring( 0, tag.lastIndexOf( '/' ))
     tagList.push( tag )
   }
-}
-
-/**
- * Create date from passed string
- *
- * @param {String} date - string date in the format *YYYY*
- * @returns {Date} newly created date object
- */
-export function createYearArgument( date: string ): Date {
-  const dateComp = date.split( ',' )
-  // cannot simply replace '-' as need to support negative years
-  return new Date( +( dateComp[0] ?? 0 ), +( dateComp[1] ?? 0 ), +( dateComp[2] ?? 0 ), +( dateComp[3] ?? 0 ))
 }
 
 /**

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -1,0 +1,73 @@
+/**
+ * Takes a date string and normalizes it so there are always 4 sections, each the length specified by maxDigits
+ * If there are missing sections, they will be inserted with a value of 01 (except for hours, which will be 00)
+ *
+ * @param date - a date string of some nebulous format
+ * @param maxDigits - the number of digits to pad each section to
+ *
+ * @returns {string}
+ */
+export const normalizeDate = ( date: string, maxDigits: number ): string => {
+  // todo: handle sections of arbitrary length
+  let isNegativeYear = false
+  if ( date[0] === '-' ) {
+    isNegativeYear = true
+    date = date.substring( 1 )
+  }
+
+  const sections = date.split( '-' )
+
+  // cases:
+  // 4 sections: YYYY-MM-DD-HH (perfect, send it off as is)
+  // 3 sections: YYYY-MM-DD (add 00 at the end)
+  // 2 sections: YYYY-MM (add 01-00 at the end)
+  // 1 section: YYYY (add 01-01-00 at the end)
+
+  switch ( sections.length ) {
+  case 1:
+    sections.push( '01' ) // MM
+  case 2:
+    sections.push( '01' ) // DD
+  case 3:
+    sections.push( '00' ) // HH
+    break
+  }
+
+  const paddedSections = sections.map(( section ) => {
+    return section.padStart( maxDigits, '0' )
+  })
+
+  if ( isNegativeYear ) {
+    paddedSections[0] = `-${paddedSections[0]}`
+  }
+
+  return paddedSections.join( '-' )
+}
+
+/**
+ * Format an event date for display
+ *
+ * @param {string} rawDate - string from of date in format "YYYY-MM-DD-HH"
+ * @returns {Date | null}
+ */
+export const buildTimelineDate = ( rawDate: string ): Date | null => {
+  let cleanedDate = rawDate?.replace( /(.*)-\d{4}$/g, '$1' )
+  if ( !cleanedDate ) {
+    return null
+  }
+
+  let isNegative: boolean = false
+  if ( cleanedDate[0] === '-' ) {
+    isNegative = true
+    cleanedDate = cleanedDate.slice( 1 )
+  }
+
+  const parts = cleanedDate.split( '-' )
+  const year = parseInt( parts[0] ) * ( isNegative ? -1 : 1 )
+  const month = parseInt( parts[1] ?? '1' ) - 1 // Month is 0-indexed, so subtract 1
+  const day = parseInt( parts[2] ?? '1' )
+  const hour = parseInt( parts[3] ?? '1' )
+
+  const date = new Date( year, month, day, hour )
+  return date
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -11,11 +11,12 @@ import { CardContainer } from '../types'
 import { logger } from './debug'
 import { parseTag } from './arguments'
 
+export * from './arguments'
+export * from './colors'
+export * from './dates'
 export * from './debug'
 export * from './events'
 export * from './frontmatter'
-export * from './arguments'
-export * from './colors'
 
 /**
  * Filter markdown files by tag
@@ -74,80 +75,6 @@ export function getImgUrl( vault: Vault, path: string ): string {
   if ( file instanceof TFile ) {
     return vault.getResourcePath( file )
   }
-}
-
-/**
- * Takes a date string and normalizes it so there are always 4 sections, each the length specified by maxDigits
- * If there are missing sections, they will be inserted with a value of 01 (except for hours, which will be 00)
- *
- * @param date - a date string of some nebulous format
- * @param maxDigits - the number of digits to pad each section to
- *
- * @returns {string}
- */
-export const normalizeDate = ( date: string, maxDigits: number ): string => {
-  // todo: handle sections of arbitrary length
-  let isNegativeYear = false
-  if ( date[0] === '-' ) {
-    isNegativeYear = true
-    date = date.substring( 1 )
-  }
-
-  const sections = date.split( '-' )
-
-  // cases:
-  // 4 sections: YYYY-MM-DD-HH (perfect, send it off as is)
-  // 3 sections: YYYY-MM-DD (add 00 at the end)
-  // 2 sections: YYYY-MM (add 01-00 at the end)
-  // 1 section: YYYY (add 01-01-00 at the end)
-
-  switch ( sections.length ) {
-  case 1:
-    sections.push( '01' ) // MM
-  case 2:
-    sections.push( '01' ) // DD
-  case 3:
-    sections.push( '00' ) // HH
-    break
-  }
-
-  const paddedSections = sections.map(( section ) => {
-    return section.padStart( maxDigits, '0' )
-  })
-
-  if ( isNegativeYear ) {
-    paddedSections[0] = `-${paddedSections[0]}`
-  }
-
-  return paddedSections.join( '-' )
-}
-
-/**
- * Format an event date for display
- *
- * @param {string} rawDate - string from of date in format "YYYY-MM-DD-HH"
- * @returns {Date | null}
- */
-export const buildTimelineDate = ( rawDate: string ): Date | null => {
-  let cleanedDate = rawDate?.replace( /(.*)-\d{4}$/g, '$1' )
-  if ( !cleanedDate ) {
-    return null
-  }
-
-  let isNegative: boolean = false
-  if ( cleanedDate[0] === '-' ) {
-    isNegative = true
-    cleanedDate = cleanedDate.slice( 1 )
-  }
-
-  const parts = cleanedDate.split( '-' )
-  const year = parseInt( parts[0] ) * ( isNegative ? -1 : 1 )
-  const month = parseInt( parts[1] ?? '1' ) - 1 // Month is 0-indexed, so subtract 1
-  const day = parseInt( parts[2] ?? '1' )
-  const hour = parseInt( parts[3] ?? '1' )
-
-  const date = new Date( year, month, day, hour )
-  return date
 }
 
 /**


### PR DESCRIPTION
### v2.1.12

Fix issue: `Refined Horizontal Timeline View` [#49](https://github.com/seanlowe/obsidian-timelines/issues/49)

**Changes**:
- removed incorrect function `createYearArgument` in favour of using `buildTimelineDate` everywhere a Date is needed
- move `normalizeDate` and `buildTimelineDate` from `utils/index.ts` to own file `dates.ts` to avoid a circular dependency
- updated docs with some extra info regarding this change

---

Resolves #49 