### PR TITLE
Preliminary commit for vertical timeline ranged events

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,15 @@ I've written a brand new GitHub Pages docs site for **Timelines (Revamped)** at 
 
 ## Release Notes
 
-### v2.1.13
+### v2.1.14
 
-Fix issue: `Timelines with negative dates render in the wrong order` [#22](https://github.com/seanlowe/obsidian-timelines/issues/22), and some other miscellaneous changes.
+Added support for time spanning events in vertical timelines
 
 **Changes**:
-- write new function for sorting the unique timeline date ID's
-- overhaul function `buildTimelineDates` to accurately handle use cases where the built-in JS `Date` object fell short
-- write new function `cleanDate` to take a normalized date and return one where all leading zeros have been removed
-- changed `normalizeDate` to append a `01` instead of `00` for missing hour sections
-- small docs change
-- added a contributors section on the README
-- updated LICENSE to 2024
-- deleted unnecessary copy of README from before docs overhaul
+- overhauled `buildVerticalTimeline()`
+- overhauled `vertical-timeline.scss`
+- changed `endDate` to default to the same as start date rather than null
+- added `DOM.Iterable` to `tsconfig.json`
 
 See the [changelog](./changelog.md) for more details on previous releases.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,19 @@
 ## Changelog
 
+### v2.1.13
+
+Fix issue: `Timelines with negative dates render in the wrong order` [#22](https://github.com/seanlowe/obsidian-timelines/issues/22), and some other miscellaneous changes.
+
+**Changes**:
+- write new function for sorting the unique timeline date ID's
+- overhaul function `buildTimelineDates` to accurately handle use cases where the built-in JS `Date` object fell short
+- write new function `cleanDate` to take a normalized date and return one where all leading zeros have been removed
+- changed `normalizeDate` to append a `01` instead of `00` for missing hour sections
+- small docs change
+- added a contributors section on the README
+- updated LICENSE to 2024
+- deleted unnecessary copy of README from before docs overhaul
+
 ### v2.1.12
 
 Fix issue: `Refined Horizontal Timeline View` [#49](https://github.com/seanlowe/obsidian-timelines/issues/49)

--- a/src/block.ts
+++ b/src/block.ts
@@ -311,8 +311,9 @@ export class TimelineBlockProcessor {
         event.preventDefault()
         const collapsed = !JSON.parse( noteDiv[0].getAttribute( 'collapsed' ))
         noteDiv[0].setAttribute( 'collapsed', String( collapsed ))
-        noteDiv[0].getElementsByTagName( 'p' )[0]?.setCssProps({ 'display': collapsed ? 'none' : 'block' })
-
+        for( const p of noteDiv[0].getElementsByTagName( 'p' )) {
+          p.setCssProps({ 'display': collapsed ? 'none' : 'block' })
+        }
         /* If this event has a duration (and thus has an end note), we hide all elements between the start and end
            note along with the end note itself */
         if( lengthy ) {

--- a/src/block.ts
+++ b/src/block.ts
@@ -258,7 +258,7 @@ export class TimelineBlockProcessor {
       const start   = timelineNotes[date][0].startDate
       const end     = timelineNotes[date][0].endDate
       const era     = timelineNotes[date][0].era
-      const lengthy = timelineNotes[date][0].type !== 'point' && end > start
+      const lengthy = /^(background|range)$/.test( timelineNotes[date][0].type ) && end > start
       const align   = eventCount % 2 === 0 ? 'left' : 'right'
       const datedTo = [
         start.replace( /-0*$/g, '' ) + ( era ? ` ${era}` : '' ),

--- a/src/block.ts
+++ b/src/block.ts
@@ -266,9 +266,9 @@ export class TimelineBlockProcessor {
       const noteDiv = [timeline.createDiv({
         cls: ['timeline-container', `timeline-${align}`]
       }, div => {
-        div.setAttribute( 'collapsed', 'false' )
         div.style.setProperty( '--timeline-indent', '0' )
         div.setAttribute( 'timeline-date', start )
+        div.setAttribute( 'collapsed', String( false ))
       })]
       const eventsDiv = noteDiv[0].createDiv({
         cls: 'timeline-event-list',
@@ -310,19 +310,18 @@ export class TimelineBlockProcessor {
 
       noteDiv[0].addEventListener( 'click', ( event ) => {
         event.preventDefault()
-        const collapsed = noteDiv[0].getAttribute( 'collapsed' ) === 'true' ? 'false' : 'true'
-        const display = collapsed === 'true' ? 'none' : 'block'
-        noteDiv[0].setAttribute( 'collapsed', collapsed )
-        noteDiv[0].getElementsByTagName( 'p' )[0]?.setCssProps({ 'display': display })
+        const collapsed = !JSON.parse( noteDiv[0].getAttribute( 'collapsed' ))
+        noteDiv[0].setAttribute( 'collapsed', String( collapsed ))
+        noteDiv[0].getElementsByTagName( 'p' )[0]?.setCssProps({ 'display': collapsed ? 'none' : 'block' })
 
         /* If this event has a duration (and thus has an end note), we hide all elements between the start and end
            note along with the end note itself */
         if( noteDiv[1] ) {
-          noteHdr[0].setText( noteDiv[0].getText() === datedTo[0] ? datedTo[2] : datedTo[0] )
+          noteHdr[0].setText( collapsed ? datedTo[2] : datedTo[0] )
           const notes = Array.from( timeline.children ) as HTMLElement[]
           const inner = notes.slice( notes.indexOf( noteDiv[0] ) + 1, notes.indexOf( noteDiv[1] ) + 1 )
           inner.forEach(( note: HTMLDivElement & { calcLength?: () => void }) => {
-            note.style.display = display
+            note.style.display = collapsed ? 'none' : 'block'
             note.calcLength?.()
           })
         }

--- a/src/block.ts
+++ b/src/block.ts
@@ -299,7 +299,7 @@ export class TimelineBlockProcessor {
            then these elements will not be responsive to layout changes. */
         ( noteDiv[1] as HTMLDivElement & { calcLength?: () => void }).calcLength = () =>  {
           const axisMin = noteDiv[0].getBoundingClientRect().top
-          const axisMax = noteHdr[1].getBoundingClientRect().bottom
+          const axisMax = noteDiv[1].getBoundingClientRect().top
           const spanMin = noteHdr[0].getBoundingClientRect().bottom
           const spanMax = noteHdr[1].getBoundingClientRect().top
           noteDiv[0].style.setProperty( '--timeline-span-length', `${axisMax - axisMin}px` )

--- a/src/block.ts
+++ b/src/block.ts
@@ -385,7 +385,7 @@ export class TimelineBlockProcessor {
          dates of the current event) are placed before their predecessor. */
       for( let s = [...timeline.children],i = s.indexOf( noteDiv[0] ); s[i-1]?.classList.contains( 'timeline-tail' ); i-- ) {
         const t = s[i-1].getAttribute( 'timeline-date' )
-        for( let j = [start, end, t].sort().lastIndexOf( t ); j++ > 0; s[i-1].before( ...noteDiv.slice( 0, j | ( j = 0 )))) {
+        for( let j = [start, end, t].sort().lastIndexOf( t ); j > 0; s[i-1].before( ...noteDiv.slice( 0, j )), j = 0 ) {
           const indent = +noteDiv[0].style.getPropertyValue( '--timeline-indent' ) + 1
           noteDiv.forEach( n => {
             n.style.setProperty( '--timeline-indent', `${ indent }` )

--- a/src/block.ts
+++ b/src/block.ts
@@ -318,7 +318,7 @@ export class TimelineBlockProcessor {
            note along with the end note itself */
         if( noteDiv[1] ) {
           noteHdr[0].setText( collapsed ? datedTo[2] : datedTo[0] )
-          const notes = Array.from( timeline.children ) as HTMLElement[]
+          const notes = [...timeline.children]
           const inner = notes.slice( notes.indexOf( noteDiv[0] ) + 1, notes.indexOf( noteDiv[1] ) + 1 )
           inner.forEach(( note: HTMLDivElement & { calcLength?: () => void }) => {
             note.style.display = collapsed ? 'none' : 'block'
@@ -328,7 +328,7 @@ export class TimelineBlockProcessor {
 
         /* The CSS '--timeline-indent' variable allows for scaling down the event when contained within another event,
            but in this case it also tells us how many time spanning events have had their length altered as a consequence
-           of this event's mutation. */
+           of this note's mutation. */
         let nested = +noteDiv[0].style.getPropertyValue( '--timeline-indent' ) + ( noteDiv[1] ? 1 : 0 )
         for( let f = 'nextElementSibling', sibling = noteDiv[0][f]; nested > 0; sibling = sibling[f] ) {
           if( sibling.classList.contains( 'timeline-tail' )) {

--- a/src/block.ts
+++ b/src/block.ts
@@ -255,10 +255,11 @@ export class TimelineBlockProcessor {
     let eventCount = 0
     // Build the timeline html element
     for ( const date of timelineDates ) {
-      const start = timelineNotes[date][0].startDate
-      const end   = timelineNotes[date][0].endDate
-      const era   = timelineNotes[date][0].era
-      const align = eventCount % 2 === 0 ? 'left' : 'right'
+      const start   = timelineNotes[date][0].startDate
+      const end     = timelineNotes[date][0].endDate
+      const era     = timelineNotes[date][0].era
+      const lengthy = timelineNotes[date][0].type !== 'point' && end > start
+      const align   = eventCount % 2 === 0 ? 'left' : 'right'
       const datedTo = [
         start.replace( /-0*$/g, '' ) + ( era ? ` ${era}` : '' ),
         end  .replace( /-0*$/g, '' ) + ( era ? ` ${era}` : '' )
@@ -279,9 +280,7 @@ export class TimelineBlockProcessor {
         text: datedTo[0]
       })]
 
-      /* Ending date now defaults to the same as starting date, here we determine whether the ending date merits further
-         handling the event differently. */
-      if ( end > start ) {
+      if ( lengthy ) {
         datedTo[2] = datedTo[0] + ' to ' + datedTo[1]
         noteDiv[0].classList.add( 'timeline-head' )
         noteDiv[1] = timeline.createDiv({
@@ -316,7 +315,7 @@ export class TimelineBlockProcessor {
 
         /* If this event has a duration (and thus has an end note), we hide all elements between the start and end
            note along with the end note itself */
-        if( noteDiv[1] ) {
+        if( lengthy ) {
           noteHdr[0].setText( collapsed ? datedTo[2] : datedTo[0] )
           const notes = [...timeline.children]
           const inner = notes.slice( notes.indexOf( noteDiv[0] ) + 1, notes.indexOf( noteDiv[1] ) + 1 )
@@ -329,7 +328,7 @@ export class TimelineBlockProcessor {
         /* The CSS '--timeline-indent' variable allows for scaling down the event when contained within another event,
            but in this case it also tells us how many time spanning events have had their length altered as a consequence
            of this note's mutation. */
-        let nested = +noteDiv[0].style.getPropertyValue( '--timeline-indent' ) + ( noteDiv[1] ? 1 : 0 )
+        let nested = +noteDiv[0].style.getPropertyValue( '--timeline-indent' ) + ( lengthy ? 1 : 0 )
         for( let f = 'nextElementSibling', sibling = noteDiv[0][f]; nested > 0; sibling = sibling[f] ) {
           if( sibling.classList.contains( 'timeline-tail' )) {
             sibling.calcLength?.()

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -89,7 +89,7 @@ export const getEventData = (
   const defaultBody    = isHTMLElementType( eventObject ) ? eventObject.innerText : ''
   const color          = retrieveEventValue( eventObject, 'color', '' )
   const endDate        = retrieveEventValue(
-    eventObject, 'endDate', null, frontMatterKeys?.endDateKey
+    eventObject, 'endDate', startDate, frontMatterKeys?.endDateKey
   )
   const era            = retrieveEventValue( eventObject, 'era', null )
   const eventImg       = retrieveEventValue( eventObject, 'img', null )

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -59,6 +59,6 @@
     flex-direction: column;
     justify-content: space-between;
     word-break: break-word;
-    white-space: normal;
+    white-space: pre-wrap;
   }
 }

--- a/styles/vertical-timeline.scss
+++ b/styles/vertical-timeline.scss
@@ -154,10 +154,6 @@ $event-widget-border-width: 4px;
   }
 }
 
-.timeline-card p {
-  white-space: pre-wrap;
-}
-
 /* Place the container to the left */
 .timeline-left {
     left: calc($timeline-indent-gap * var(--timeline-indent));

--- a/styles/vertical-timeline.scss
+++ b/styles/vertical-timeline.scss
@@ -14,11 +14,11 @@ $event-widget-border-width: 4px;
   &::after {
   content: '';
   position: absolute;
-  width:            $timeline-line-width;
+  width: $timeline-line-width;
   background-color: var(--background-secondary);
   top: 0;
   bottom: 0;
-  left:  calc(50% - $timeline-line-width / 2);
+  left: calc(50% - $timeline-line-width / 2);
   }
 }
 
@@ -30,26 +30,28 @@ $event-widget-border-width: 4px;
   width: calc(50% - (var(--timeline-indent) * $timeline-indent-gap));
 
   /* Arrow pointing from note to widget */
-  &:not(.timeline-tail)::before {
-    content: " ";
-    height: 0;
-    position: absolute;
-    top: 22px;
-    width: 0;
-    z-index: 1;
-    border: medium solid var(--background-secondary);
-  }
+  &:not(.timeline-tail){
+    &::before {
+      content: " ";
+      height: 0;
+      position: absolute;
+      top: 22px;
+      width: 0;
+      z-index: 1;
+      border: medium solid var(--background-secondary);
+    }
 
-  &.timeline-left:not(.timeline-tail)::before {
-    right: 30px;
-    border-width: 10px 0 10px 10px;
-    border-color: transparent transparent transparent var(--background-secondary);
-  }
+    &.timeline-left::before {
+      right: 30px;
+      border-width: 10px 0 10px 10px;
+      border-color: transparent transparent transparent var(--background-secondary);
+    }
 
-  &.timeline-right:not(.timeline-tail)::before {
-    left: 30px;
-    border-width: 10px 10px 10px 0;
-    border-color: transparent var(--background-secondary) transparent transparent;
+    &.timeline-right::before {
+      left: 30px;
+      border-width: 10px 10px 10px 0;
+      border-color: transparent var(--background-secondary) transparent transparent;
+    }
   }
 
   /* The normal circle widget for events on the timeline */

--- a/styles/vertical-timeline.scss
+++ b/styles/vertical-timeline.scss
@@ -1,6 +1,10 @@
-$timeline-indent-gap: 25px;
+$note-segment-width: 10px;
 $timeline-line-width: 10px;
-$timeline-widget-inset: 15px;
+$timeline-indent-gap: 25px;
+$timeline-arrow-width: 10px;
+$timeline-arrow-margin: 30px;
+$timeline-note-padding: 40px;
+$timeline-widget-inset: 25px;
 $point-event-widget-width: 25px;
 $range-event-widget-width: 33px;
 $event-widget-border-width: 4px;
@@ -24,32 +28,32 @@ $event-widget-border-width: 4px;
 
 /* Container around content */
 .timeline-container {
-  padding: 10px 40px;
+  padding: 10px $timeline-note-padding;
   position: relative;
   background-color: inherit;
   width: calc(50% - (var(--timeline-indent) * $timeline-indent-gap));
 
   /* Arrow pointing from note to widget */
-  &:not(.timeline-tail){
+  & {
     &::before {
       content: " ";
       height: 0;
       position: absolute;
-      top: 22px;
+      top: $timeline-widget-inset - $timeline-arrow-width / 2;
       width: 0;
       z-index: 1;
       border: medium solid var(--background-secondary);
     }
 
     &.timeline-left::before {
-      right: 30px;
-      border-width: 10px 0 10px 10px;
+      right: $timeline-arrow-margin;
+      border-width: $timeline-arrow-width 0 $timeline-arrow-width $timeline-arrow-width;
       border-color: transparent transparent transparent var(--background-secondary);
     }
 
     &.timeline-right::before {
-      left: 30px;
-      border-width: 10px 10px 10px 0;
+      left: $timeline-arrow-margin;
+      border-width: $timeline-arrow-width $timeline-arrow-width $timeline-arrow-width 0;
       border-color: transparent var(--background-secondary) transparent transparent;
     }
   }
@@ -63,16 +67,16 @@ $event-widget-border-width: 4px;
       height: $point-event-widget-width;
       background-color: var(--background-secondary);
       border: $event-widget-border-width solid #FF9F55;
-      top: $timeline-widget-inset;
-      border-radius: 25px;
+      top: $timeline-widget-inset - $point-event-widget-width / 2;
+      border-radius: $point-event-widget-width;
       z-index: 1;
     }
 
     &.timeline-left::after {
-      right: - calc($point-event-widget-width / 2 + $event-widget-border-width);
+      right: - $point-event-widget-width / 2 - $event-widget-border-width;
     }
     &.timeline-right::after {
-      left: - calc($point-event-widget-width / 2 + $event-widget-border-width);
+      left: - $point-event-widget-width / 2 - $event-widget-border-width;
     }
   }
 
@@ -86,36 +90,66 @@ $event-widget-border-width: 4px;
       height:           calc(var(--timeline-span-length) - $timeline-widget-inset);
       background-color: var(--background-secondary);
       border: $event-widget-border-width solid #00DB00;
-      top: $timeline-widget-inset;
-      border-radius: 33px;
+      top: $timeline-widget-inset - $range-event-widget-width / 2;
+      border-radius: $range-event-widget-width;
       z-index: 1;
     }
     &.timeline-left::after {
-      right: - calc($range-event-widget-width / 2 + $event-widget-border-width);
+      right: - $range-event-widget-width / 2 - $event-widget-border-width;
     }
     &.timeline-right::after {
-      left: - calc($range-event-widget-width / 2 + $event-widget-border-width);
+      left: - $range-event-widget-width / 2 - $event-widget-border-width;
     }
   }
 
   /* The line segment joining dates for time spanning events */
   &.timeline-tail {
-    & > h2::after {
-      $gap: 25px;
+    $gap: 20px;
 
+    & > h2{
+      padding-top: 20px;;
+    }
+    & > h2::before {
+      content: "";
+      display: block;
+      width: calc(100% - $timeline-note-padding - $timeline-arrow-width - $timeline-arrow-margin);
+      height: $note-segment-width;
+      background-color: var(--background-secondary);
+      position: absolute;
+      top: $timeline-widget-inset;
+    }
+    &.timeline-left > h2::before {
+      left: 0;
+      margin-left: $timeline-note-padding;
+      border-bottom-left-radius: $note-segment-width;
+    }
+
+    &.timeline-right > h2::before {
+      right: 0;
+      margin-right: $timeline-note-padding;
+      border-bottom-right-radius: $note-segment-width;
+    }
+
+    & > h2::after {
       content: "";
       position: absolute;
       transform: translateY(calc(-100% - $gap));
-      width: 4px;
-      height: calc(var(--timeline-span-length) - 2 * $gap);
-      background-color: var(--text-normal);
+      width: $note-segment-width;
+      height: calc(var(--timeline-span-length) - $gap);
+      background-color: var(--background-secondary);
+      border-top-left-radius: $note-segment-width;
+      border-top-right-radius: $note-segment-width;
     }
     &.timeline-left > h2::after {
-      left: 50px;
+      left: 0;
+      margin-left: $timeline-note-padding;
+      border-bottom-right-radius: - $note-segment-width;
     }
 
     &.timeline-right > h2::after {
-      right: 50px;
+      right: 0;
+      margin-right: $timeline-note-padding;
+      border-bottom-left-radius: - $note-segment-width;
     }
   }
 }
@@ -126,7 +160,7 @@ $event-widget-border-width: 4px;
 
 /* Place the container to the left */
 .timeline-left {
-    left: calc(var(--timeline-indent) * $timeline-indent-gap);
+    left: calc($timeline-indent-gap * var(--timeline-indent));
 }
 
 /* Place the container to the right */

--- a/styles/vertical-timeline.scss
+++ b/styles/vertical-timeline.scss
@@ -1,41 +1,121 @@
+$timeline-indent-gap: 25px;
+$timeline-line-width: 10px;
+$timeline-widget-inset: 15px;
+$point-event-widget-width: 25px;
+$range-event-widget-width: 33px;
+$event-widget-border-width: 4px;
+
 /* The actual timeline (the vertical ruler) */
 .timeline {
-    position: relative;
-    max-width: 1200px;
-    margin: 0 auto;
+  position: relative;
+  max-width: 1200px;
+  margin: 0 auto;
 
-    &::after {
-    content: '';
-    position: absolute;
-    width: 10px;
-    background-color: var(--background-secondary);
-    top: 0;
-    bottom: 0;
-    left: 50%;
-    margin-left: -3px;
-    }
+  &::after {
+  content: '';
+  position: absolute;
+  width:            $timeline-line-width;
+  background-color: var(--background-secondary);
+  top: 0;
+  bottom: 0;
+  left:  calc(50% - $timeline-line-width / 2);
+  }
 }
 
 /* Container around content */
 .timeline-container {
-    padding: 10px 40px;
-    position: relative;
-    background-color: inherit;
-    width: 50%;
+  padding: 10px 40px;
+  position: relative;
+  background-color: inherit;
+  width: calc(50% - (var(--timeline-indent) * $timeline-indent-gap));
 
-    /* The circles on the timeline */
+  /* Arrow pointing from note to widget */
+  &:not(.timeline-tail)::before {
+    content: " ";
+    height: 0;
+    position: absolute;
+    top: 22px;
+    width: 0;
+    z-index: 1;
+    border: medium solid var(--background-secondary);
+  }
+
+  &.timeline-left:not(.timeline-tail)::before {
+    right: 30px;
+    border-width: 10px 0 10px 10px;
+    border-color: transparent transparent transparent var(--background-secondary);
+  }
+
+  &.timeline-right:not(.timeline-tail)::before {
+    left: 30px;
+    border-width: 10px 10px 10px 0;
+    border-color: transparent var(--background-secondary) transparent transparent;
+  }
+
+  /* The normal circle widget for events on the timeline */
+  &:not(.timeline-head):not(.timeline-tail) {
     &::after {
-        content: '';
-        position: absolute;
-        width: 25px;
-        height: 25px;
-        right: -17px;
-        background-color: var(--background-secondary);
-        border: 4px solid #FF9F55;
-        top: 15px;
-        border-radius: 50%;
-        z-index: 1;
+      content: '';
+      position: absolute;
+      width: $point-event-widget-width;
+      height: $point-event-widget-width;
+      background-color: var(--background-secondary);
+      border: $event-widget-border-width solid #FF9F55;
+      top: $timeline-widget-inset;
+      border-radius: 25px;
+      z-index: 1;
     }
+
+    &.timeline-left::after {
+      right: - calc($point-event-widget-width / 2 + $event-widget-border-width);
+    }
+    &.timeline-right::after {
+      left: - calc($point-event-widget-width / 2 + $event-widget-border-width);
+    }
+  }
+
+  /* The elongated circle widget for time spanning events on the timeline */
+  &.timeline-head {
+    &::after {
+      content: '';
+      position: absolute;
+      width:            $range-event-widget-width;
+      min-height:       $range-event-widget-width;
+      height:           calc(var(--timeline-span-length) - $timeline-widget-inset);
+      background-color: var(--background-secondary);
+      border: $event-widget-border-width solid #00DB00;
+      top: $timeline-widget-inset;
+      border-radius: 33px;
+      z-index: 1;
+    }
+    &.timeline-left::after {
+      right: - calc($range-event-widget-width / 2 + $event-widget-border-width);
+    }
+    &.timeline-right::after {
+      left: - calc($range-event-widget-width / 2 + $event-widget-border-width);
+    }
+  }
+
+  /* The line segment joining dates for time spanning events */
+  &.timeline-tail {
+    & > h2::after {
+      $gap: 25px;
+
+      content: "";
+      position: absolute;
+      transform: translateY(calc(-100% - $gap));
+      width: 4px;
+      height: calc(var(--timeline-span-length) - 2 * $gap);
+      background-color: var(--text-normal);
+    }
+    &.timeline-left > h2::after {
+      left: 50px;
+    }
+
+    &.timeline-right > h2::after {
+      right: 50px;
+    }
+  }
 }
 
 .timeline-card p {
@@ -44,44 +124,15 @@
 
 /* Place the container to the left */
 .timeline-left {
-    left: 0;
-
-    /* Add arrows to the left container (pointing right) */
-    &::before {
-        content: " ";
-        height: 0;
-        position: absolute;
-        top: 22px;
-        width: 0;
-        z-index: 1;
-        right: 30px;
-        border: medium solid var(--background-secondary);
-        border-width: 10px 0 10px 10px;
-        border-color: transparent transparent transparent var(--background-secondary);
-    }
+    left: calc(var(--timeline-indent) * $timeline-indent-gap);
 }
 
 /* Place the container to the right */
 .timeline-right {
     left: 50%;
 
-    /* Add arrows to the right container (pointing left) */
-    &::before {
-        content: " ";
-        height: 0;
-        position: absolute;
-        top: 22px;
-        width: 0;
-        z-index: 1;
-        left: 30px;
-        border: medium solid var(--background-secondary);
-        border-width: 10px 10px 10px 0;
-        border-color: transparent var(--background-secondary) transparent transparent;
-    }
-
-    /* Fix the circle for containers on the right side */
-    &::after {
-        left: -16px;
+    &.timeline-timespan-end::after {
+      right: 10px;
     }
 }
 

--- a/styles/vertical-timeline.scss
+++ b/styles/vertical-timeline.scss
@@ -9,6 +9,8 @@ $point-event-widget-width: 25px;
 $range-event-widget-width: 33px;
 $event-widget-border-width: 4px;
 
+$corrective-modifying-offset: 50px;
+
 /* The actual timeline (the vertical ruler) */
 .timeline {
   position: relative;
@@ -39,10 +41,15 @@ $event-widget-border-width: 4px;
       content: " ";
       height: 0;
       position: absolute;
-      top: $timeline-widget-inset - $timeline-arrow-width / 2;
       width: 0;
       z-index: 1;
       border: medium solid var(--background-secondary);
+    }
+    &:not(.timeline-tail)::before {
+      top: $timeline-widget-inset - $timeline-arrow-width / 2;
+    }
+    &.timeline-tail::before {
+      bottom: $timeline-widget-inset - $timeline-arrow-width / 2 + $corrective-modifying-offset;
     }
 
     &.timeline-left::before {
@@ -87,7 +94,7 @@ $event-widget-border-width: 4px;
       position: absolute;
       width:            $range-event-widget-width;
       min-height:       $range-event-widget-width;
-      height:           calc(var(--timeline-span-length) - $timeline-widget-inset);
+      height:           calc(var(--timeline-span-length) - $corrective-modifying-offset);
       background-color: var(--background-secondary);
       border: $event-widget-border-width solid #00DB00;
       top: $timeline-widget-inset - $range-event-widget-width / 2;
@@ -107,7 +114,7 @@ $event-widget-border-width: 4px;
     $gap: 20px;
 
     & > h2{
-      padding-top: 20px;;
+      padding-top: $gap;
     }
     & > h2::before {
       content: "";

--- a/styles/vertical-timeline.scss
+++ b/styles/vertical-timeline.scss
@@ -35,13 +35,19 @@ $event-widget-border-width: 4px;
 
   /* Arrow pointing from note to widget */
   & {
+    &.timeline-left > h2 {
+      margin-left: $timeline-indent-gap;
+    }
+    &.timeline-right > h2 {
+      margin-right: $timeline-indent-gap;
+    }
     &::before {
       content: " ";
       width: 0;
       height: 0;
       position: absolute;
       top: $timeline-widget-inset - $timeline-arrow-width / 2;
-      z-index: 1;
+      z-index: 2;
       border: medium solid var(--background-secondary);
     }
 
@@ -104,30 +110,35 @@ $event-widget-border-width: 4px;
 
   /* The line segment joining dates for time spanning events */
   &.timeline-tail {
+    $border-width: 5px;
     $gap: 20px;
 
-    & > h2{
+    & > h2 {
       padding-top: $gap;
     }
     & > h2::before {
       content: "";
       display: block;
-      width: calc(100% - $timeline-note-padding - $timeline-arrow-width - $timeline-arrow-margin);
+      width: calc(100% - $timeline-note-padding - $timeline-arrow-width - $timeline-arrow-margin + $border-width);
       height: $note-segment-width;
       background-color: var(--background-secondary);
       position: absolute;
       top: $timeline-widget-inset;
+      border-bottom: $border-width solid var(--background-primary);
+      z-index: 1;
     }
     &.timeline-left > h2::before {
-      left: 0;
+      left: -$border-width;
       margin-left: $timeline-note-padding;
-      border-bottom-left-radius: $note-segment-width;
+      border-left: $border-width solid var(--background-primary);
+      border-bottom-left-radius: $note-segment-width * 2;
     }
 
     &.timeline-right > h2::before {
-      right: 0;
+      right: -$border-width;
       margin-right: $timeline-note-padding;
-      border-bottom-right-radius: $note-segment-width;
+      border-right: $border-width solid var(--background-primary);
+      border-bottom-right-radius: $note-segment-width * 2;
     }
 
     & > h2::after {
@@ -135,21 +146,20 @@ $event-widget-border-width: 4px;
       position: absolute;
       transform: translateY(calc(-100% - $gap));
       width: $note-segment-width;
-      height: calc(var(--timeline-span-length) - $gap);
+      height: calc(var(--timeline-span-length));
       background-color: var(--background-secondary);
       border-top-left-radius: $note-segment-width;
       border-top-right-radius: $note-segment-width;
+      z-index: 0;
     }
     &.timeline-left > h2::after {
       left: 0;
       margin-left: $timeline-note-padding;
-      border-bottom-right-radius: - $note-segment-width;
     }
 
     &.timeline-right > h2::after {
       right: 0;
       margin-right: $timeline-note-padding;
-      border-bottom-left-radius: - $note-segment-width;
     }
   }
 }

--- a/styles/vertical-timeline.scss
+++ b/styles/vertical-timeline.scss
@@ -1,6 +1,6 @@
 $note-segment-width: 10px;
 $timeline-line-width: 10px;
-$timeline-indent-gap: 25px;
+$timeline-indent-gap: 20px;
 $timeline-arrow-width: 10px;
 $timeline-arrow-margin: 30px;
 $timeline-note-padding: 40px;
@@ -8,8 +8,6 @@ $timeline-widget-inset: 25px;
 $point-event-widget-width: 25px;
 $range-event-widget-width: 33px;
 $event-widget-border-width: 4px;
-
-$corrective-modifying-offset: 50px;
 
 /* The actual timeline (the vertical ruler) */
 .timeline {
@@ -39,17 +37,12 @@ $corrective-modifying-offset: 50px;
   & {
     &::before {
       content: " ";
+      width: 0;
       height: 0;
       position: absolute;
-      width: 0;
+      top: $timeline-widget-inset - $timeline-arrow-width / 2;
       z-index: 1;
       border: medium solid var(--background-secondary);
-    }
-    &:not(.timeline-tail)::before {
-      top: $timeline-widget-inset - $timeline-arrow-width / 2;
-    }
-    &.timeline-tail::before {
-      bottom: $timeline-widget-inset - $timeline-arrow-width / 2 + $corrective-modifying-offset;
     }
 
     &.timeline-left::before {
@@ -94,7 +87,7 @@ $corrective-modifying-offset: 50px;
       position: absolute;
       width:            $range-event-widget-width;
       min-height:       $range-event-widget-width;
-      height:           calc(var(--timeline-span-length) - $corrective-modifying-offset);
+      height:           calc(var(--timeline-span-length) + $range-event-widget-width);
       background-color: var(--background-secondary);
       border: $event-widget-border-width solid #00DB00;
       top: $timeline-widget-inset - $range-event-widget-width / 2;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "inlineSources": true,
     "lib": [
       "dom",
+      "DOM.Iterable",
       "es5",
       "scripthost",
       "es2015"


### PR DESCRIPTION
![image](https://github.com/seanlowe/obsidian-timelines/assets/115123556/5e3ba3d2-52a2-463c-a251-f1968866dc66)
![image](https://github.com/seanlowe/obsidian-timelines/assets/115123556/a28bfc9b-8d55-477d-8515-6e042719e61b)

In a working state, can you see if you have any comments? Things to note so far:

1. You originally had the note, "TODO: Stop Propagation: don't close timeline-card when clicked." I'm not certain what your intention was but the current behavior is that clicking a note leaves any thumbnail and title visible but hides the body, as well as hiding any events encapsulated by a time spanning event.

2. Currently nested spanning events are supported but having a spanning event that begins inside another but ends outside of it is undefined behavior

3. I'm no color theorist and find the green color I randomly plugged to be quite jarring. Additionally, I think nested spanning events would benefit from having differently colored widgets