### PR TITLE
Fixed dead links in Docs

### DIFF
--- a/docs/content/docs/00_overview/00_overview.md
+++ b/docs/content/docs/00_overview/00_overview.md
@@ -25,7 +25,7 @@ Please take the time to read all the way through. Thanks!
 
 <br>
 
-See the changelog from the last major update to view any breaking changes [here](./changelog.md#v200).
+See the changelog from the last major update to view any breaking changes [here](https://github.com/seanlowe/obsidian-timelines/blob/main/changelog.md#v200).
 
 ### Examples
 

--- a/docs/content/docs/01_guides/00_getting_started/01_insert.md
+++ b/docs/content/docs/01_guides/00_getting_started/01_insert.md
@@ -35,7 +35,7 @@ tags=now;test
 
 The render block takes a single line which is the _list of tags_ (separated by semicolons) by which to filter timeline-tagged notes. For example, in the above example block, **<u>only notes with all</u>** three tags (`now`, `test` and `timeline`) will be rendered.
 
-> Read more about available arguments [here](../arguments.md). 
+> Read more about available arguments [here](../../../03_arguments/). 
 
 (Don't worry, we'll come back this later when we look at horizontal timelines.)
 

--- a/docs/content/docs/01_guides/00_getting_started/02_adding_events.md
+++ b/docs/content/docs/01_guides/00_getting_started/02_adding_events.md
@@ -15,7 +15,7 @@ There are 2 ways to include a note in a timeline:
 
 We're going to use HTML, as it's a little simpler.
 
-> Read more about events [here](../events)
+> Read more about events [here](../../../02_events/)
 
 There's a handy little command for inserting an HTML command into a note of our choice.
 

--- a/docs/content/docs/01_guides/01_other_guides/00_insert_horizontal/01_insert_horizontal.md
+++ b/docs/content/docs/01_guides/01_other_guides/00_insert_horizontal/01_insert_horizontal.md
@@ -8,7 +8,7 @@ toc: false
 
 <br></br>
 
-As we focused on vertical timelines in the previous guide "[**Getting Started**](../00_getting_started)", here we'll add a simple horizontal timeline.
+As we focused on vertical timelines in the previous guide "[**Getting Started**](../../../00_getting_started)", here we'll add a simple horizontal timeline.
 
 The codeblock for horizontal timelines is more involved. We have a total of **eight** possible parameters, although only **two** are actually required.
 


### PR DESCRIPTION
Hey there,
when going through the [docs ](https://seanlowe.github.io/obsidian-timelines/docs/)I saw that some of the links were dead so I quickly fixed them.