### PR TITLE
68 bug horizontal perfectly functional timelines but countless notifications of no date found for    md for each event everytime i open the timeline note

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,14 @@ I've written a brand new GitHub Pages docs site for **Timelines (Revamped)** at 
 
 ## Release Notes
 
-### v2.2.1
+### v2.2.2
 
-Fix issue: `Flat timeline doesn't render.` [#60](https://github.com/seanlowe/obsidian-timelines/issues/60)
+Fix issue: `[Bug - Horizontal] Perfectly functional timelines, but countless notifications of "no date found for ___.md" (for each event), everytime I open the timeline note.` [#68](https://github.com/seanlowe/obsidian-timelines/issues/68)
 
 **Changes:**
-- pass additional parameters to `buildHorizontalTimeline` that are now required due to being in its own file
-- create interface type for the input to `buildHorizontalTimeline`
+- add check to make sure a frontmatter "event" makes sense before trying to retrieve event data from it
+
+Also includes some improvements to debugging logs so that it's easier to find the information needed.
 
 See the [changelog](./changelog.md) for more details on previous releases.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 ## Changelog
 
+### v2.2.1
+
+Fix issue: `Flat timeline doesn't render.` [#60](https://github.com/seanlowe/obsidian-timelines/issues/60)
+
+**Changes:**
+- pass additional parameters to `buildHorizontalTimeline` that are now required due to being in its own file
+- create interface type for the input to `buildHorizontalTimeline`
+
 ### v2.2.0
 
 Implement Issue: `Feature suggestion, time spans in vertical timelines` [#52](https://github.com/seanlowe/obsidian-timelines/issues/52): Added support for time spanning events in vertical timelines

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
   "id": "timelines-revamped",
   "name": "Timelines (Revamped)",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "minAppVersion": "0.10.11",
-  "description": "Generate a chronological timeline in which all 'events' are notes that include a specific tag or set of tags.",
+  "description": "Successor to darakah's Timelines plugin: Generate a chronological timeline in which all 'events' are notes that include a specific tag or set of tags.",
   "author": "seanlowe",
   "authorUrl": "https://github.com/seanlowe/",
   "isDesktopOnly": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "timelines-revamped",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "timelines-revamped",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "MIT",
       "dependencies": {
         "chroma-js": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timelines-revamped",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Generate a chronological timeline in which all 'events' are notes that include a specific tag or set of tags.",
   "main": "main.js",
   "scripts": {

--- a/src/block.ts
+++ b/src/block.ts
@@ -95,6 +95,15 @@ export class TimelineBlockProcessor {
       combinedEventsAndFrontMatter.forEach(( event ) => {
         let eventData = null
 
+        if ( !isHTMLElementType( event ) && Object.keys( event ).length < 3 ) {
+          console.warn(
+            'parseFiles | event has fewer than 3 keys. Required keys for Frontmatter events are:',
+            [ 'startDate', 'endDate', 'showOnTimeline' ]
+          )      
+
+          return
+        }
+
         eventData = getEventData( event, file, this.settings.frontMatterKeys )
         if ( !eventData ) {
           console.warn( `malformed eventData, skipping event in file: ${file.name}`, { event, eventData })


### PR DESCRIPTION
### v2.2.2

Fix issue: `[Bug - Horizontal] Perfectly functional timelines, but countless notifications of "no date found for ___.md" (for each event), everytime I open the timeline note.` # 68

**Changes:**
- add check to make sure a frontmatter "event" makes sense before trying to retrieve event data from it

Also includes some improvements to debugging logs so that it's easier to find the information needed.

---

Resolves #68 