### PR TITLE
add new command for #74

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,13 @@ I've written a brand new GitHub Pages docs site for **Timelines (Revamped)** at 
 
 ## Release Notes
 
-### v2.2.2
 
-Fix issue: `[Bug - Horizontal] Perfectly functional timelines, but countless notifications of "no date found for ___.md" (for each event), everytime I open the timeline note.` [#68](https://github.com/seanlowe/obsidian-timelines/issues/68)
+### v2.2.3
+
+Implement issue: `[Feature] A Hotkey or command to redraw the timeline after edit` [#74](https://github.com/seanlowe/obsidian-timelines/issues/74)
 
 **Changes:**
-- add check to make sure a frontmatter "event" makes sense before trying to retrieve event data from it
-
-Also includes some improvements to debugging logs so that it's easier to find the information needed.
+- added a new command: `Reload current note`. Thanks to [dataview](https://github.com/blacksmithgu/obsidian-dataview) for adding this functionality initially and I just yoinked it for this plugin. Woot Woot MIT licensure!
 
 See the [changelog](./changelog.md) for more details on previous releases.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,14 @@
 ## Changelog
 
+### v2.2.2
+
+Fix issue: `[Bug - Horizontal] Perfectly functional timelines, but countless notifications of "no date found for ___.md" (for each event), everytime I open the timeline note.` [#68](https://github.com/seanlowe/obsidian-timelines/issues/68)
+
+**Changes:**
+- add check to make sure a frontmatter "event" makes sense before trying to retrieve event data from it
+
+Also includes some improvements to debugging logs so that it's easier to find the information needed.
+
 ### v2.2.1
 
 Fix issue: `Flat timeline doesn't render.` [#60](https://github.com/seanlowe/obsidian-timelines/issues/60)

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "timelines-revamped",
   "name": "Timelines (Revamped)",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "minAppVersion": "0.10.11",
   "description": "Successor to darakah's Timelines plugin: Generate a chronological timeline in which all 'events' are notes that include a specific tag or set of tags.",
   "author": "seanlowe",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "timelines-revamped",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "timelines-revamped",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "MIT",
       "dependencies": {
         "chroma-js": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timelines-revamped",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Generate a chronological timeline in which all 'events' are notes that include a specific tag or set of tags.",
   "main": "main.js",
   "scripts": {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,9 +1,17 @@
-import { Vault, MetadataCache, MarkdownView, Workspace } from 'obsidian'
+import { Vault, MetadataCache, MarkdownView, Workspace, WorkspaceLeaf } from 'obsidian'
 
 import { RENDER_TIMELINE } from './constants'
 import TimelinesPlugin from './main'
 import { TimelinesSettings } from './types'
 import { confirmUserInEditor, getNumEventsInFile, logger } from './utils'
+
+// link to dataview code:
+// https://github.com/blacksmithgu/obsidian-dataview/blob/15b8d527e3d5822c5ef9bfd23f528a64769d545b/src/main.ts#L126C8-L139
+
+// credit: blacksmithgu/obsidian-dataview, main.ts lines 126-128 (as of 7/4/24)
+interface WorkspaceLeafRebuild extends WorkspaceLeaf {
+  rebuildView(): void;
+}
 
 export class TimelineCommandProcessor {
   appVault: Vault
@@ -181,5 +189,13 @@ export class TimelineCommandProcessor {
       { ch: lastCommentStartIndex - 1, line: 1 },
       source
     )
+  }
+
+
+  reloadNote = ( view: MarkdownView ) => {
+    // credit: blacksmithgu/obsidian-dataview, main.ts lines 135-137 (as of 7/4/24)
+    if ( view ) {
+      ( view.leaf as WorkspaceLeafRebuild ).rebuildView()
+    }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -79,6 +79,21 @@ export default class TimelinesPlugin extends Plugin {
       }
     })
 
+    this.addCommand({
+      id: 'reload-open-note',
+      name: 'Reload current note',
+      checkCallback: ( checking: boolean ) => {
+        const markdownView = this.app.workspace.getActiveViewOfType( MarkdownView )
+        if ( markdownView ) {
+          if ( !checking ) {
+            this.commands.reloadNote( markdownView )
+          }
+
+          return true
+        }
+      },
+    })
+
     this.addSettingTab( new TimelinesSettingTab( this.app, this ))
 
     this.addRibbonIcon( 'code-2', 'Insert Timeline Event', async () => {


### PR DESCRIPTION
### v2.2.3

Implement issue: `[Feature] A Hotkey or command to redraw the timeline after edit` [#74](https://github.com/seanlowe/obsidian-timelines/issues/74)

**Changes:**
- added a new command: `Reload current note`. Thanks to [dataview](https://github.com/blacksmithgu/obsidian-dataview) for adding this functionality initially and I just yoinked it for this plugin. Woot Woot MIT licensure!

---

Resolves #74 