### PR TITLE
fix #67

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,12 @@ I've written a brand new GitHub Pages docs site for **Timelines (Revamped)** at 
 
 ## Release Notes
 
+### v2.2.4
 
-### v2.2.3
-
-Implement issue: `[Feature] A Hotkey or command to redraw the timeline after edit` [#74](https://github.com/seanlowe/obsidian-timelines/issues/74)
+Fix issue: `[Bug - Vertical] collapsing an event that is not a time range changes date to "undefined"` [#67](https://github.com/seanlowe/obsidian-timelines/issues/67)
 
 **Changes:**
-- added a new command: `Reload current note`. Thanks to [dataview](https://github.com/blacksmithgu/obsidian-dataview) for adding this functionality initially and I just yoinked it for this plugin. Woot Woot MIT licensure!
+- added small sanity check when displaying the "A to B" time string on collapsed events to make sure the string actually exists
 
 See the [changelog](./changelog.md) for more details on previous releases.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 ## Changelog
 
+### v2.2.3
+
+Implement issue: `[Feature] A Hotkey or command to redraw the timeline after edit` [#74](https://github.com/seanlowe/obsidian-timelines/issues/74)
+
+**Changes:**
+- added a new command: `Reload current note`. Thanks to [dataview](https://github.com/blacksmithgu/obsidian-dataview) for adding this functionality initially and I just yoinked it for this plugin. Woot Woot MIT licensure!
+
 ### v2.2.2
 
 Fix issue: `[Bug - Horizontal] Perfectly functional timelines, but countless notifications of "no date found for ___.md" (for each event), everytime I open the timeline note.` [#68](https://github.com/seanlowe/obsidian-timelines/issues/68)

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "timelines-revamped",
   "name": "Timelines (Revamped)",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "minAppVersion": "0.10.11",
   "description": "Successor to darakah's Timelines plugin: Generate a chronological timeline in which all 'events' are notes that include a specific tag or set of tags.",
   "author": "seanlowe",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "timelines-revamped",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "timelines-revamped",
-      "version": "2.2.3",
+      "version": "2.2.4",
       "license": "MIT",
       "dependencies": {
         "chroma-js": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timelines-revamped",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Generate a chronological timeline in which all 'events' are notes that include a specific tag or set of tags.",
   "main": "main.js",
   "scripts": {

--- a/src/timelines/vertical.ts
+++ b/src/timelines/vertical.ts
@@ -112,7 +112,7 @@ export async function buildVerticalTimeline(
       /* If this event has a duration (and thus has an end note), we hide all elements between the start and end
          note along with the end note itself */
       if ( noteDivs.length > 0 ) {
-        noteHdrs[0].setText( collapsed ? datedTo[1] : datedTo[0] )
+        noteHdrs[0].setText( collapsed && datedTo[1] ? datedTo[1] : datedTo[0] )
         const notes = [...timeline.children]
         const inner = notes.slice( notes.indexOf( noteDivs.first()) + 1, notes.indexOf( noteDivs.last()) + 1 )
         inner.forEach(( note: DivWithCalcFunc ) => {


### PR DESCRIPTION
### v2.2.4

Fix issue: `[Bug - Vertical] collapsing an event that is not a time range changes date to "undefined"` [#67](https://github.com/seanlowe/obsidian-timelines/issues/67)

**Changes:**
- added small sanity check when displaying the "A to B" time string on collapsed events to make sure the string actually exists

---

Resolves #67 