### PR TITLE
Custom attributes on timeline nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,13 @@ I've written a brand new GitHub Pages docs site for **Timelines (Revamped)** at 
 
 ## Release Notes
 
-### v2.2.4
+### v2.2.5
 
-Fix issue: `[Bug - Vertical] collapsing an event that is not a time range changes date to "undefined"` [#67](https://github.com/seanlowe/obsidian-timelines/issues/67)
+Implement feature: Custom attributes on timeline nodes [#63](https://github.com/seanlowe/obsidian-timelines/issues/63)
 
 **Changes:**
-- added small sanity check when displaying the "A to B" time string on collapsed events to make sure the string actually exists
+- added a new key to a couple types to allow passing in the argument `data-classes` to HTML (just `classes` for frontmatter)
+- updated docs with information about the new key
 
 See the [changelog](./changelog.md) for more details on previous releases.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 ## Changelog
 
+### v2.2.4
+
+Fix issue: `[Bug - Vertical] collapsing an event that is not a time range changes date to "undefined"` [#67](https://github.com/seanlowe/obsidian-timelines/issues/67)
+
+**Changes:**
+- added small sanity check when displaying the "A to B" time string on collapsed events to make sure the string actually exists
+
 ### v2.2.3
 
 Implement issue: `[Feature] A Hotkey or command to redraw the timeline after edit` [#74](https://github.com/seanlowe/obsidian-timelines/issues/74)

--- a/docs/content/docs/03_arguments/01_html_arguments.md
+++ b/docs/content/docs/03_arguments/01_html_arguments.md
@@ -53,16 +53,21 @@ For statically generated timelines, events that occur at the same time are group
 - Optional
 - If a title is not specified, the name of the note will be used
 
-## Description (`data-description`)
-- Optional
-- Redundant; If a description is not specified, the `innerText` of the `div`/`span` will be used. If neither are populated, the body of the event will be empty.
-
 ## Background Image (`data-img`)
   - Optional
   - If an image is not specified, no image will be shown (just text)
   - If an invalid url is given, an empty black section will be seen for that note card
 
 Note: Currently only assets specified via `http` or `absolute local path` will render. Obsidian release `v0.10.13` blocked obsidian links for background images. 
+
+## Classes (`data-classes`):
+  - Optional
+  - A list of classes to append to an event item's class list. There is no indication that these classes are added until you create an obsidian CSS snippet (or something similar) to define the styling rules for that class.
+  - This works pretty much as expected on vertical timelines. On horizontal timelines, however, if you want your class to affect the text of the event, you need to make sure you have your class selector as such: `.your-fancy-new-class > div > div > a`. This is due to how `vis-timeline` creates its elements.
+
+## Description (`data-description`)
+- Optional
+- Redundant; If a description is not specified, the `innerText` of the `div`/`span` will be used. If neither are populated, the body of the event will be empty.
 
 ## Era (`data-era`)
   - Optional
@@ -76,16 +81,6 @@ Note: Currently only assets specified via `http` or `absolute local path` will r
 
 Note: If a value is not supplied, events will be colored `white` (or `gray` for background events) on the timeline.
 
-## Type (`data-type`)
-  - Optional
-  - Tells the timeline what type of event to display for this entry.
-
-Note: Acceptable values for `data-type` are:
-  - `background`, best used for time periods
-  - `box`
-  - `point`, which is exactly what it sounds like, and
-  - `range`
-
 ## Path (`data-path`)
   - Optional
   - An alternate path to link the title to (excluding `[[` and `]]`). Default to the note the event is defined in, but you can use this to specify other notes or link to headers or blocks internally within the note. For example, `data-path='My Note#Event Subhead'` would link directly to the `Event Subhead` header in `My Note`
@@ -96,3 +91,12 @@ Note: Acceptable values for `data-type` are:
   - An override to the tags that the event should be counted with. Allows you to have a note with events on separate timelines. For example, 1 event has tag "A" and a second has tag "B". A combined timeline will display both, but now you can also have 2 separate timelines where only the applicable ("A" or "B") events will be displayed.
   - Values are a string of tags separated by semicolons, similar to the tags list on either of the codeblocks for displaying timelines. Ex: `data-tags="timeline-A;timeline-B"`
 
+## Type (`data-type`)
+  - Optional
+  - Tells the timeline what type of event to display for this entry.
+
+Note: Acceptable values for `data-type` are:
+  - `background`, best used for time periods
+  - `box`
+  - `point`, which is exactly what it sounds like, and
+  - `range`

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "timelines-revamped",
   "name": "Timelines (Revamped)",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "minAppVersion": "0.10.11",
   "description": "Successor to darakah's Timelines plugin: Generate a chronological timeline in which all 'events' are notes that include a specific tag or set of tags.",
   "author": "seanlowe",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "timelines-revamped",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "timelines-revamped",
-      "version": "2.2.4",
+      "version": "2.2.5",
       "license": "MIT",
       "dependencies": {
         "chroma-js": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timelines-revamped",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Generate a chronological timeline in which all 'events' are notes that include a specific tag or set of tags.",
   "main": "main.js",
   "scripts": {

--- a/src/block.ts
+++ b/src/block.ts
@@ -1,7 +1,14 @@
 import type { TFile, MetadataCache, Vault } from 'obsidian'
 
 import { buildHorizontalTimeline, buildVerticalTimeline, showEmptyTimelineMessage } from './timelines'
-import { AllNotesData, CardContainer, HorizontalTimelineInput, InternalTimelineArgs, TimelinesSettings } from './types'
+import {
+  AllNotesData,
+  CardContainer,
+  EventDataObject,
+  HorizontalTimelineInput,
+  InternalTimelineArgs,
+  TimelinesSettings
+} from './types'
 import {
   buildTimelineDate,
   createTagList,
@@ -87,13 +94,13 @@ export class TimelineBlockProcessor {
   async parseFiles(
     timelineNotes: AllNotesData,
     timelineDates: string[]
-  ) {
+  ): Promise<void> {
     for ( const file of this.currentFileList ) {
       const combinedEventsAndFrontMatter = await getEventsInFile( file, this.appVault, this.metadataCache )
       const { numEvents } = await getNumEventsInFile( null, combinedEventsAndFrontMatter )
 
       combinedEventsAndFrontMatter.forEach(( event ) => {
-        let eventData = null
+        let eventData: EventDataObject | null = null
 
         if ( !isHTMLElementType( event ) && Object.keys( event ).length < 3 ) {
           console.warn(
@@ -121,6 +128,7 @@ export class TimelineBlockProcessor {
         }
 
         const {
+          classes,
           color: initialColor,
           endDate,
           era,
@@ -174,6 +182,7 @@ export class TimelineBlockProcessor {
 
         const note: CardContainer = {
           id: noteId,
+          classes,
           color,
           endDate: cleanedEndDate,
           era,

--- a/src/timelines/horizontal.ts
+++ b/src/timelines/horizontal.ts
@@ -35,7 +35,7 @@ export async function buildHorizontalTimeline(
     // add all events at this date
     Object.values( timelineNotes[date] ).forEach(( event: CardContainer ) => {
       const noteCard = document.createElement( 'div' )
-      noteCard.className = 'timeline-card'
+      noteCard.className = 'timeline-card ' + event.classes
 
       // add an image only if available
       if ( event.img ) {
@@ -65,11 +65,13 @@ export async function buildHorizontalTimeline(
         return
       }
 
+      const initialClassName = colorIsClass ? event.color ?? 'gray' : `nid-${event.id}`
+
       const eventItem: EventItem = {
         id: items.length + 1,
         content: event.title ?? '',
         start: start,
-        className: colorIsClass ? event.color ?? 'gray' : `nid-${event.id}`,
+        className: initialClassName + ' ' + event.classes,
         type: event.type,
         end: end ?? null,
         path: event.path,

--- a/src/timelines/vertical.ts
+++ b/src/timelines/vertical.ts
@@ -1,4 +1,4 @@
-import { AllNotesData, DivWithCalcFunc } from '../types'
+import { AllNotesData, CardContainer, DivWithCalcFunc } from '../types'
 import { buildTimelineDate, createInternalLinkOnNoteCard, handleColor } from '../utils'
 
 /**
@@ -44,7 +44,9 @@ export async function buildVerticalTimeline(
       text: datedTo[0]
     })]
 
-    for ( const note of timelineNotes[date] ) {
+    for ( const rawNote of timelineNotes[date] ) {
+      // for confirmation of types
+      const note: CardContainer = rawNote
       const { endDate: endDateString, era } = note
       const startDate = buildTimelineDate( note.startDate )
       const endDate = buildTimelineDate( endDateString )
@@ -65,7 +67,7 @@ export async function buildVerticalTimeline(
       }
 
       const noteDiv = timeline.createDiv(
-        { cls: ['timeline-container', `timeline-${align}`, 'timeline-tail'] }, 
+        { cls: ['timeline-container', `timeline-${align}`, 'timeline-tail'] },
         ( div ) => {
           div.style.setProperty( '--timeline-indent', '0' )
           div.setAttribute( 'timeline-date', endDateString )
@@ -155,6 +157,7 @@ export async function buildVerticalTimeline(
 
     for ( const eventAtDate of timelineNotes[date] ) {
       const noteCard = eventsDiv.createDiv({ cls: 'timeline-card' })
+      noteCard.className += ` ${eventAtDate.classes}`
       // add an image only if available
       if ( eventAtDate.img ) {
         noteCard.createDiv({

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export interface CleanedDateResultObject {
 export interface CardContainer {
   id: string,
   body: string,
+  classes: string,
   color: string,
   endDate: string,
   era: string,
@@ -35,6 +36,7 @@ export interface CardContainer {
 }
 
 export interface EventDataObject {
+  classes: string,
   color: string,
   endDate: string,
   era: string,

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -88,6 +88,7 @@ export const getEventData = (
   }
 
   const defaultBody    = isHTMLElementType( eventObject ) ? eventObject.innerText : ''
+  const classes        = retrieveEventValue( eventObject, 'classes', '' )
   const color          = retrieveEventValue( eventObject, 'color', '' )
   const endDate        = retrieveEventValue(
     eventObject, 'endDate', startDate, frontMatterKeys?.endDateKey
@@ -104,6 +105,7 @@ export const getEventData = (
   const showOnTimeline = retrieveEventValue( eventObject, 'showOnTimeline', null )
 
   const eventData: EventDataObject = {
+    classes,
     color,
     endDate,
     era,


### PR DESCRIPTION
### v2.2.5

Implement feature: Custom attributes on timeline nodes [#63](https://github.com/seanlowe/obsidian-timelines/issues/63)

**Changes:**
- added a new key to a couple types to allow passing in the argument `data-classes` to HTML (just `classes` for frontmatter)
- updated docs with information about the new key

---

Allows the passing of custom attributes (classes) that can be targeted in obsidian CSS snippets or custom JS scripts

Resolves #63 