### PR TITLE
make sure new attribute is on the insert commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ I've written a brand new GitHub Pages docs site for **Timelines (Revamped)** at 
 
 ## Release Notes
 
-### v2.2.5
+### v2.2.6
 
-Implement feature: Custom attributes on timeline nodes [#63](https://github.com/seanlowe/obsidian-timelines/issues/63)
+Bug Fix for: `Custom attributes on timeline nodes` [#63](https://github.com/seanlowe/obsidian-timelines/issues/63)
 
 **Changes:**
-- added a new key to a couple types to allow passing in the argument `data-classes` to HTML (just `classes` for frontmatter)
-- updated docs with information about the new key
+- added the correct changes to the `insert event` commands so that events inserted that way have all the applicable attributes.
+- added a new page in the docs for understanding how to add custom classes to your timeline events.
 
 See the [changelog](./changelog.md) for more details on previous releases.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 ## Changelog
 
+### v2.2.5
+
+Implement feature: Custom attributes on timeline nodes [#63](https://github.com/seanlowe/obsidian-timelines/issues/63)
+
+**Changes:**
+- added a new key to a couple types to allow passing in the argument `data-classes` to HTML (just `classes` for frontmatter)
+- updated docs with information about the new key
+
 ### v2.2.4
 
 Fix issue: `[Bug - Vertical] collapsing an event that is not a time range changes date to "undefined"` [#67](https://github.com/seanlowe/obsidian-timelines/issues/67)

--- a/docs/content/docs/01_guides/01_other_guides/02_customization/01_show_html_events.md
+++ b/docs/content/docs/01_guides/01_other_guides/02_customization/01_show_html_events.md
@@ -17,6 +17,7 @@ Timeline span and div entries (.ob-timelines class) are hidden in preview by def
   display: inline-block !important;
   font-style: italic;
 }
+
 /* Use the before pseudo element to display attributes of the span or div */
 .ob-timelines::before {
   content: "🔖 " attr(data-start-date) ": " attr(data-title) ".";

--- a/docs/content/docs/01_guides/01_other_guides/02_customization/03_custom_classes_on_events.md
+++ b/docs/content/docs/01_guides/01_other_guides/02_customization/03_custom_classes_on_events.md
@@ -1,0 +1,38 @@
+---
+weight: 242
+title: Adding custom classes to timeline events
+description: The `classes` attribute allows for custom classes on timeline events
+icon: palette
+draft: false
+toc: false
+---
+
+Added in release v2.2.5, there is now an attribute `data-classes` that can be added to HTML events for passing along CSS class names onto the events on the timeline. For frontmatter events, the key is just `classes` and it's just a single string with spaces inbetween values, should you have multiple classes you want to add.
+
+Without doing anything else, adding the `classes` attribute will have no impact on your timeline or its events. Because the plugin has no knowledge of what these classes might possibly be, it is up to the user to create an Obsidian snippet and define the rules you wish to place on that CSS class manually.
+
+For vertical timelines, it's as simple as just adding your class directly, like so:
+```css
+.your-fancy-new-class {
+  text-decoration: unset;
+  color: rebeccapurple;
+}
+```
+
+However, for horizontal timelines, due to the way the library used generates the timeline, you must tweak the snippet like so:
+```css
+.your-fancy-new-class > div > div > a {
+  text-decoration: unset !important;
+  color: rebeccapurple !important;
+}
+```
+
+It is generally frowned upon to use `!important` in CSS rules but without it, your new styles will just get overridden.
+
+For the most complete setup, you can use this as a starting point for your CSS snippet:
+```css
+.your-fancy-new-class,
+.your-fancy-new-class > div > div > a {
+  /* put your rules here */
+}
+```

--- a/docs/content/docs/02_events/02_html_events.md
+++ b/docs/content/docs/02_events/02_html_events.md
@@ -19,7 +19,7 @@ Examples of HTML events:
   data-img='absolute/path/to/image.png'
   data-type='background'
 >
-	Some Time Period that only lasted 10 days
+  Some Time Period that only lasted 10 days
 </span>
 
 <div
@@ -29,7 +29,7 @@ Examples of HTML events:
   data-title='Another Event'
   data-type='range'
 >
-	A minimal event
+  A minimal event
 </div>
 ```
 
@@ -39,14 +39,15 @@ A timeline entry can be created using `span` or `div` HTML elements (`div` is th
 
 ```html
 <div class="ob-timelines"
-	data-title=""
-	data-color=""
-	data-type=""
-	data-start-date=""
-	data-end-date=""
-	data-era=""
-	data-path=""
-	data-tags=""
+  data-title=""
+  data-classes=""
+  data-color=""
+  data-type=""
+  data-start-date=""
+  data-end-date=""
+  data-era=""
+  data-path=""
+  data-tags=""
 > some content </div>
 ```
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "timelines-revamped",
   "name": "Timelines (Revamped)",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "minAppVersion": "0.10.11",
   "description": "Successor to darakah's Timelines plugin: Generate a chronological timeline in which all 'events' are notes that include a specific tag or set of tags.",
   "author": "seanlowe",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "timelines-revamped",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "timelines-revamped",
-      "version": "2.2.5",
+      "version": "2.2.6",
       "license": "MIT",
       "dependencies": {
         "chroma-js": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timelines-revamped",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "Generate a chronological timeline in which all 'events' are notes that include a specific tag or set of tags.",
   "main": "main.js",
   "scripts": {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -104,6 +104,7 @@ export class TimelineCommandProcessor {
     newEventElement.setAttribute( 'class', 'ob-timelines' )
     newEventElement.setAttribute( 'data-title', '' )
     newEventElement.setAttribute( 'data-description', '' )
+    newEventElement.setAttribute( 'data-classes', '' )
     newEventElement.setAttribute( 'data-color', '' )
     newEventElement.setAttribute( 'data-type', '' )
     newEventElement.setAttribute( 'data-start-date', '' )
@@ -134,6 +135,7 @@ export class TimelineCommandProcessor {
     const frontmatterJson = {
       title: '',
       description: '',
+      classes: '',
       color: '',
       type: '',
       startDate: '',
@@ -191,7 +193,11 @@ export class TimelineCommandProcessor {
     )
   }
 
-
+  /**
+   * Reload the current note without having to reload the entire application.
+   *
+   * @param {MarkdownView} view - the current view (the note, it's just the note.)
+   */
   reloadNote = ( view: MarkdownView ) => {
     // credit: blacksmithgu/obsidian-dataview, main.ts lines 135-137 (as of 7/4/24)
     if ( view ) {


### PR DESCRIPTION
### v2.2.6

Bug Fix for: `Custom attributes on timeline nodes` [#63](https://github.com/seanlowe/obsidian-timelines/issues/63)

**Changes:**
- added the correct changes to the `insert event` commands so that events inserted that way have all the applicable attributes.
- added a new page in the docs for understanding how to add custom classes to your timeline events.

---

Resolves #63 