### PR TITLE
Bug fix for issue: `"YYYY" Format`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ I've written a brand new GitHub Pages docs site for **Timelines (Revamped)** at 
 
 ## Release Notes
 
-### v2.2.6
+### v2.2.7
 
-Bug Fix for: `Custom attributes on timeline nodes` [#63](https://github.com/seanlowe/obsidian-timelines/issues/63)
+Bug fix for issue: `"YYYY" Format` [#81](https://github.com/seanlowe/obsidian-timelines/issues/81)
 
 **Changes:**
-- added the correct changes to the `insert event` commands so that events inserted that way have all the applicable attributes.
-- added a new page in the docs for understanding how to add custom classes to your timeline events.
+- implemented some logic to determine what sections of the provided dates are missing originally and to not display a cleaned version of the normalized date but a "readable" date that should closer match what the user provides in the event.
+- tweaked some logic in the nesting / sorting functionality on the vertical timeline. Events now sort the start and end of time ranges correctly (so far as I can tell).
 
 See the [changelog](./changelog.md) for more details on previous releases.
 

--- a/archive/pre-vertical-refactor.txt
+++ b/archive/pre-vertical-refactor.txt
@@ -1,0 +1,207 @@
+import { AllNotesData, CardContainer, DivWithCalcFunc } from '../types'
+import { buildTimelineDate, createInternalLinkOnNoteCard, handleColor } from '../utils'
+
+export async function buildVerticalTimeline(
+  timeline: HTMLElement,
+  timelineNotes: AllNotesData,
+  timelineDates: string[],
+  el: HTMLElement
+) {
+  let eventCount = 0
+  // Build the timeline html element
+  for ( const date of timelineDates ) {
+    const align   = eventCount % 2 === 0 ? 'left' : 'right'
+    const datedTo = [ timelineNotes[date][0].startDate.replace( /-0*$/g, '' )
+                  + ( timelineNotes[date][0].era ? ` ${timelineNotes[date][0].era}` : '' )
+    ]
+
+    const noteDivs = [
+      timeline.createDiv(
+        { cls: ['timeline-container', `timeline-${align}`] }, 
+        ( div ) => {
+          div.style.setProperty( '--timeline-indent', '0' )
+          div.setAttribute( 'timeline-date', timelineNotes[date][0].startDate )
+          div.setAttribute( 'collapsed', 'false' )
+        }
+      )
+    ]
+
+    const eventsDiv = noteDivs[0].createDiv({
+      cls: 'timeline-event-list',
+      attr: { 'style': 'display: block' }
+    })
+
+    const noteHdrs = [noteDivs[0].createEl( 'h2', {
+      attr: { 'style' : `text-align: ${align};` },
+      text: datedTo[0]
+    })]
+
+    for ( const rawNote of timelineNotes[date] ) {
+      // for confirmation of types
+      const note: CardContainer = rawNote
+      const { endDate: endDateString, era } = note
+      const startDate = buildTimelineDate( note.startDate )
+      const endDate = buildTimelineDate( endDateString )
+
+      // skip events that are of type 'box' or 'point', or if the endDate is invalid
+      if ( ['box', 'point'].includes( note.type ) || endDate < startDate ) {
+        continue
+      }
+
+      if ( !noteDivs[0].classList.contains( 'timeline-head' )) {
+        noteDivs[0].classList.add( 'timeline-head' ) 
+      }
+
+      const dated = endDateString + ( era ?? '' )
+      const lastTimelineDate = buildTimelineDate( noteDivs.last().getAttribute( 'timeline-date' ))
+      if ( !datedTo[1] || endDate > lastTimelineDate ) {
+        datedTo[1] = datedTo[0] + ' to ' + dated
+      }
+
+      const noteDiv = timeline.createDiv(
+        { cls: ['timeline-container', `timeline-${align}`, 'timeline-tail'] },
+        ( div ) => {
+          div.style.setProperty( '--timeline-indent', '0' )
+          div.setAttribute( 'timeline-date', endDateString )
+        }
+      )
+      
+      const noteHdr = noteDiv.createEl( 'h2', {
+        attr: { 'style' : `text-align: ${align};` },
+        text: dated
+      })
+
+      noteHdrs.push( noteHdr )
+      noteDivs.push( noteDiv )
+      for ( const n of noteDivs ) {
+        const timelineDate = buildTimelineDate( n.getAttribute( 'timeline-date' ))
+
+        if ( timelineDate > endDate ) {
+          n.before( noteDiv )
+        }
+      }
+
+      /* The CSS 'timeline-timespan-length' determines both the length of the event timeline widget on the timeline,
+           and the length of the vertical segment that spans between the displayed dates. If this value is not recalculated
+           then these elements will not be responsive to layout changes. */
+      ( noteDivs.last() as DivWithCalcFunc ).calcLength = () => {
+        const axisMin = noteDivs[0].getBoundingClientRect().top
+        const axisMax = noteDiv    .getBoundingClientRect().top
+        const spanMin = noteHdrs[0].getBoundingClientRect().top
+        const spanMax = noteHdr    .getBoundingClientRect().top
+
+        noteDivs[0].style.setProperty( '--timeline-span-length', `${axisMax - axisMin}px` )
+        noteDiv    .style.setProperty( '--timeline-span-length', `${spanMax - spanMin}px` )
+      }
+    }
+
+    noteDivs[0].addEventListener( 'click', ( event ) => {
+      event.preventDefault()
+
+      const collapsed = !JSON.parse( noteDivs[0].getAttribute( 'collapsed' ))
+      noteDivs[0].setAttribute( 'collapsed', String( collapsed ))
+      for ( const p of noteDivs[0].getElementsByTagName( 'p' )) {
+        p.setCssProps({ 'display': collapsed ? 'none' : 'block' })
+      }
+      /* If this event has a duration (and thus has an end note), we hide all elements between the start and end
+         note along with the end note itself */
+      if ( noteDivs.length > 0 ) {
+        noteHdrs[0].setText( collapsed && datedTo[1] ? datedTo[1] : datedTo[0] )
+        const notes = [...timeline.children]
+        const inner = notes.slice( notes.indexOf( noteDivs.first()) + 1, notes.indexOf( noteDivs.last()) + 1 )
+        inner.forEach(( note: DivWithCalcFunc ) => {
+          note.style.display = collapsed ? 'none' : 'block'
+          note.calcLength?.()
+        })
+      }
+
+      /* The CSS '--timeline-indent' variable allows for scaling down the event when contained within another event,
+         but in this case it also tells us how many time spanning events have had their length altered as a consequence
+         of this note's mutation. */
+      let nested = +noteDivs[0].style.getPropertyValue( '--timeline-indent' ) + noteDivs.length - 1
+      for ( let f = 'nextElementSibling', sibling = noteDivs[0][f]; nested > 0; sibling = sibling[f] ) {
+        if ( sibling.classList.contains( 'timeline-tail' )) {
+          sibling.calcLength?.()
+          nested--
+        }
+      }
+    })
+
+
+    /*noteContainer[0].addEventListener( 'click', ( event ) => {
+      event.preventDefault()
+      const currentStyle = eventContainer.style
+      if ( currentStyle.getPropertyValue( 'display' ) === 'none' ) {
+        currentStyle.setProperty( 'display', 'block' )
+        return
+      }
+
+      // note from https://github.com/Darakah/obsidian-timelines/pull/58
+      // TODO: Stop Propagation: don't close timeline-card when clicked.
+      // `vis-timeline-graph2d.js` contains a method called `_updateContents` that makes the display
+      // attribute disappear on click via line 7426: `element.innerHTML = '';`
+      currentStyle.setProperty( 'display', 'none' )
+    })*/
+
+    if ( !timelineNotes[date] ) {
+      continue 
+    }
+
+    for ( const eventAtDate of timelineNotes[date] ) {
+      const noteCard = eventsDiv.createDiv({ cls: 'timeline-card' })
+      noteCard.className += ` ${eventAtDate.classes}`
+      // add an image only if available
+      if ( eventAtDate.img ) {
+        noteCard.createDiv({
+          cls: 'thumb',
+          attr: { style: `background-image: url(${eventAtDate.img});` }
+        })
+      }
+
+      if ( eventAtDate.color ) {
+        // todo : add more support for other custom classes
+        handleColor( eventAtDate.color, noteCard, eventAtDate.id )
+      }
+
+      createInternalLinkOnNoteCard( eventAtDate, noteCard )
+      eventAtDate.body && noteCard.createEl( 'p', { text: eventAtDate.body.trim() })
+    }
+
+    /* If the previous note is of class 'timeline-tail' then there's a chance that the current node belongs nested within
+       the previous one. Here we iterate backwards for as long as elements of the class 'timeline-tail' are encountered.
+
+       Then we sort an array containing the start and ending date of the current event along with the ending date of the
+       previous event. If the index of the ending date of the previous event in the new array is greater than 0 then the
+       note(s) preceding it (either the note belonging to the start date or the notes belonging to both the start and end
+       dates of the current event) are placed before their predecessor. */
+    for ( let s = [...timeline.children],i = s.indexOf( noteDivs[0] ); s[i-1]?.classList.contains( 'timeline-tail' ); i-- ) {
+      const t = s[i-1].getAttribute( 'timeline-date' )
+      const times = [
+        t,
+        ...noteDivs.map(( n ) => {
+          return n.getAttribute( 'timeline-date' )
+        })
+      ]
+
+      const lastTIndex = times.sort().lastIndexOf( t )
+      for ( let j = lastTIndex; j > 0; s[i-1].before( ...noteDivs.slice( 0, j )), j = 0 ) {
+        const indent = +noteDivs[0].style.getPropertyValue( '--timeline-indent' ) + 1
+        noteDivs.forEach(( n ) => {
+          n.style.setProperty( '--timeline-indent', `${ indent }` )
+        })
+      }
+    }
+
+    eventCount++
+  }
+
+  // Replace the selected tags with the timeline html
+  el.appendChild( timeline )
+
+  // Initial length calculation must be done after appending notes to document
+  el.querySelectorAll( '.timeline-tail' ).forEach(( note: DivWithCalcFunc ) => {
+    note.calcLength?.()
+  })
+
+  return
+}

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 ## Changelog
 
+### v2.2.6
+
+Bug Fix for: `Custom attributes on timeline nodes` [#63](https://github.com/seanlowe/obsidian-timelines/issues/63)
+
+**Changes:**
+- added the correct changes to the `insert event` commands so that events inserted that way have all the applicable attributes.
+- added a new page in the docs for understanding how to add custom classes to your timeline events.
+
 ### v2.2.5
 
 Implement feature: Custom attributes on timeline nodes [#63](https://github.com/seanlowe/obsidian-timelines/issues/63)

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "timelines-revamped",
   "name": "Timelines (Revamped)",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "minAppVersion": "0.10.11",
   "description": "Successor to darakah's Timelines plugin: Generate a chronological timeline in which all 'events' are notes that include a specific tag or set of tags.",
   "author": "seanlowe",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "timelines-revamped",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "timelines-revamped",
-      "version": "2.2.6",
+      "version": "2.2.7",
       "license": "MIT",
       "dependencies": {
         "chroma-js": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timelines-revamped",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "Generate a chronological timeline in which all 'events' are notes that include a specific tag or set of tags.",
   "main": "main.js",
   "scripts": {

--- a/src/block.ts
+++ b/src/block.ts
@@ -1,5 +1,4 @@
 import type { TFile, MetadataCache, Vault } from 'obsidian'
-import { Notice } from 'obsidian'
 
 import { buildHorizontalTimeline, buildVerticalTimeline, showEmptyTimelineMessage } from './timelines'
 import {
@@ -197,7 +196,7 @@ export class TimelineBlockProcessor {
         }
 
         if ( !normalizedEndDate ) {
-          console.log( 'get fucked' )
+          console.warn( "parseFiles | Couldn't normalize the event's end date, setting it to empty." )
           normalizedEndDate = ''
         }
 
@@ -205,14 +204,12 @@ export class TimelineBlockProcessor {
         const cleanedEndDateObject   = cleanDate( normalizedEndDate )
 
         if ( !cleanedStartDateObject ) {
-          const message = 'get fucked, no start date object'
-          new Notice( message )
+          const message = 'no start date object'
           throw new Error( message )
         }
 
         if ( !cleanedEndDateObject ) {
-          const message = 'get fucked, no end date object'
-          new Notice( message )
+          const message = 'no end date object'
           throw new Error( message )
         }
 

--- a/src/block.ts
+++ b/src/block.ts
@@ -1,4 +1,5 @@
 import type { TFile, MetadataCache, Vault } from 'obsidian'
+import { Notice } from 'obsidian'
 
 import { buildHorizontalTimeline, buildVerticalTimeline, showEmptyTimelineMessage } from './timelines'
 import {
@@ -200,8 +201,23 @@ export class TimelineBlockProcessor {
           normalizedEndDate = ''
         }
 
-        const { cleanedDateString: cleanedStartDate } = cleanDate( noteId )
-        const { cleanedDateString:  cleanedEndDate  } = cleanDate( normalizedEndDate )
+        const cleanedStartDateObject = cleanDate( noteId )
+        const cleanedEndDateObject   = cleanDate( normalizedEndDate )
+
+        if ( !cleanedStartDateObject ) {
+          const message = 'get fucked, no start date object'
+          new Notice( message )
+          throw new Error( message )
+        }
+
+        if ( !cleanedEndDateObject ) {
+          const message = 'get fucked, no end date object'
+          new Notice( message )
+          throw new Error( message )
+        }
+
+        const { cleanedDateString: cleanedStartDate } = cleanedStartDateObject
+        const { cleanedDateString:  cleanedEndDate  } = cleanedEndDateObject
 
         const note: CardContainer = {
           id: noteId,

--- a/src/block.ts
+++ b/src/block.ts
@@ -99,7 +99,17 @@ export class TimelineBlockProcessor {
       const combinedEventsAndFrontMatter = await getEventsInFile( file, this.appVault, this.metadataCache )
       const { numEvents } = await getNumEventsInFile( null, combinedEventsAndFrontMatter )
 
+      if ( !combinedEventsAndFrontMatter ) {
+        // skip this loop
+        continue
+      }
+
       combinedEventsAndFrontMatter.forEach(( event ) => {
+        if ( !event ) {
+          // skip this loop
+          return
+        }
+
         let eventData: EventDataObject | null = null
 
         if ( !isHTMLElementType( event ) && Object.keys( event ).length < 3 ) {
@@ -177,8 +187,21 @@ export class TimelineBlockProcessor {
 
         const imgUrl = getImgUrl( this.appVault, eventImg )
 
-        const { cleanedDateString: cleanedStartDate } = cleanDate( normalizeDate( startDate ))
-        const { cleanedDateString:  cleanedEndDate  } = cleanDate( normalizeDate(  endDate  ))
+        // normalizedStartDate is the same as noteId
+        let normalizedEndDate   = normalizeDate(  endDate  )
+
+        if ( !noteId ) {
+          console.error( "Cannot normalize the event's start date! Skipping" ) 
+          return
+        }
+
+        if ( !normalizedEndDate ) {
+          console.log( 'get fucked' )
+          normalizedEndDate = ''
+        }
+
+        const { cleanedDateString: cleanedStartDate } = cleanDate( noteId )
+        const { cleanedDateString:  cleanedEndDate  } = cleanDate( normalizedEndDate )
 
         const note: CardContainer = {
           id: noteId,

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -37,7 +37,6 @@ export class TimelineCommandProcessor {
       // ensure the status bar item is removed
       if ( plugin.statusBarItem ) {
         plugin.statusBarItem.remove()
-        // plugin.statusBarItem = ''
       }
 
       return

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -37,7 +37,7 @@ export class TimelineCommandProcessor {
       // ensure the status bar item is removed
       if ( plugin.statusBarItem ) {
         plugin.statusBarItem.remove()
-        plugin.statusBarItem = null
+        // plugin.statusBarItem = ''
       }
 
       return
@@ -67,11 +67,11 @@ export class TimelineCommandProcessor {
    *
    * @param workspace
    */
-  getStatusBarText = async ( workspace: Workspace ): Promise<string | null> => {
+  getStatusBarText = async ( workspace: Workspace ): Promise<string> => {
     const file = workspace.getActiveViewOfType( MarkdownView )?.file
 
     if ( !file ) {
-      return null
+      return ''
     }
 
     const { totalEvents } = await getNumEventsInFile({ file, appVault: this.appVault, fileCache: this.metadataCache }, null )
@@ -88,6 +88,10 @@ export class TimelineCommandProcessor {
 
   updateStatusBarText = async ( plugin: TimelinesPlugin ) => {
     const text = await this.getStatusBarText( plugin.app.workspace )
+    if ( text === '' ) {
+      return
+    }
+
     plugin.statusBarItem.setText( text )
   }
 
@@ -180,6 +184,9 @@ export class TimelineCommandProcessor {
 
     const renderedString = `<div class="timeline-rendered">${new Date().toString()}</div>`
     const rendered = ( new DOMParser()).parseFromString( renderedString, 'text/html' ).body.firstChild
+    if ( !rendered ) {
+      throw new Error( 'Could not generate the statically rendered timeline' )
+    }
     div.appendChild( rendered )
 
     const firstCommentEndIndex = source.indexOf( '-->' )

--- a/src/timelines/horizontal.ts
+++ b/src/timelines/horizontal.ts
@@ -30,8 +30,6 @@ export async function buildHorizontalTimeline(
   }: HorizontalTimelineInput
 ) {
   // Create a DataSet
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  // const items = new DataSet<any>( [] )
   const items = new DataSet<CombinedTimelineEventData>( [] )
 
   if ( !timelineDates ) {
@@ -135,7 +133,6 @@ export async function buildHorizontalTimeline(
     const newClass = event.className + ' runtime-hover'
     document.documentElement.style.setProperty( '--hoverHighlightColor', event._event?.color ?? 'white' )
     const timelineItem = buildCombinedTimelineDataObject( event, { className: newClass })
-    // const timelineItem = convertEventItemToDataItem({ ...event, className: newClass })
     items.updateOnly( [timelineItem] )
 
     return () => {
@@ -147,7 +144,6 @@ export async function buildHorizontalTimeline(
     const event = items.get( props.item ) as unknown as EventItem
     const newClass = event.className.split( ' runtime-hover' )[0]
     const timelineItem = buildCombinedTimelineDataObject( event, { className: newClass })
-    // const timelineItem = convertEventItemToDataItem({ ...event, className: newClass })
     items.updateOnly( [timelineItem] )
 
     return () => {

--- a/src/timelines/index.ts
+++ b/src/timelines/index.ts
@@ -9,3 +9,46 @@ export async function showEmptyTimelineMessage( el: HTMLElement, tagList: string
   timelineDiv.createEl( 'p', { text: message })
   el.appendChild( timelineDiv )
 }
+
+export function sortAndRenderNestedEvents( noteDivs: HTMLDivElement[], timeline: HTMLElement ) {
+  /* 
+   * If the previous note is of class 'timeline-tail' then there's a chance that
+   * the current node belongs nested within the previous one. Here we iterate
+   * backwards for as long as elements of the class 'timeline-tail' are encountered.
+   *
+   * Then we sort an array containing the start and ending date of the current event
+   * along with the ending date of the previous event. If the index of the ending
+   * date of the previous event in the new array is greater than 0 then the note(s)
+   * preceding it (either the note belonging to the start date or the notes belonging
+   * to both the start and end dates of the current event) are placed before their predecessor.
+   */
+
+  const timelineElements = [...timeline.children]
+  let currentIndex = timelineElements.indexOf( noteDivs[0] )
+
+  // iterate backwards through the timeline elements
+  while ( currentIndex > 0 && timelineElements[currentIndex - 1]?.classList.contains( 'timeline-tail' )) {
+    const previousElement = timelineElements[currentIndex - 1]
+    const previousDate = previousElement.getAttribute( 'timeline-date' )
+
+    // create an array of dates including the previous element's date and noteDivs' dates
+    const dates = [previousDate, ...noteDivs.map(( note ) => {
+      return note.getAttribute( 'timeline-date' ) 
+    })].sort()
+  
+    // if the previous Date is not the first item in the sorted array, reorder elements
+    const previousDateLastIndex = dates.lastIndexOf( previousDate )
+    if ( previousDateLastIndex > 0 ) {
+      const elementsToMove = noteDivs.slice( 0, previousDateLastIndex )
+      previousElement.before( ...elementsToMove )
+
+      // adjust indentation (for nested elements)
+      const currentIndent = parseInt( noteDivs[0].style.getPropertyValue( '--timeline-indent' ), 10 ) + 1
+      noteDivs.forEach(( note ) => {
+        note.style.setProperty( '--timeline-indent', `${currentIndent}` )
+      })
+    }
+
+    currentIndex--
+  }
+}

--- a/src/timelines/vertical.ts
+++ b/src/timelines/vertical.ts
@@ -1,10 +1,10 @@
+import { sortAndRenderNestedEvents } from '.'
 import { AllNotesData, CardContainer, DivWithCalcFunc } from '../types'
 import {
   buildMinimizedDateString,
   buildTimelineDate,
   createInternalLinkOnNoteCard,
   handleColor,
-  // normalizeAndCleanDate
 } from '../utils'
 
 /**
@@ -34,7 +34,6 @@ export async function buildVerticalTimeline(
     const firstDate = firstNote.startDate
     const {
       readable: readableStartDate,
-      // cleaned: datedFrom,
       normalized: normalizedStartDate,
     } = buildMinimizedDateString( firstDate )
     const datedTo = [ readableStartDate + ( firstDate.era ? ` ${firstDate.era}` : '' )]
@@ -44,9 +43,7 @@ export async function buildVerticalTimeline(
       { cls: ['timeline-container', `timeline-${align}`] },
       ( div ) => {
         div.style.setProperty( '--timeline-indent', '0' )
-        div.setAttribute( 'timeline-date', normalizedStartDate ) // should this be the normalizedDate rather than the cleaned Date?
-        // div.setAttribute( 'timeline-date', datedFrom ) // should this be the normalizedDate rather than the cleaned Date?
-        // div.setAttribute( 'timeline-date', firstDate.startDate )
+        div.setAttribute( 'timeline-date', normalizedStartDate )
         div.setAttribute( 'collapsed', 'false' )
       }
     )
@@ -61,7 +58,6 @@ export async function buildVerticalTimeline(
     containerDiv.createEl( 'h2', {
       attr: { style: `text-align: ${align};` },
       text: readableStartDate
-      // text: firstDate
     })
 
     for ( const rawNote of timelineNotes[date] ) {
@@ -91,7 +87,6 @@ export async function buildVerticalTimeline(
 
       const {
         readable: readableEndDate,
-        // cleaned: cleanedEndDate,
         normalized: normalizedEndDate
       } = buildMinimizedDateString( end )
       const endDateFormatted = readableEndDate + ( era ? ` ${era}` : '' )
@@ -112,8 +107,6 @@ export async function buildVerticalTimeline(
         ( div ) => {
           div.style.setProperty( '--timeline-indent', '0' )
           div.setAttribute( 'timeline-date', normalizedEndDate )
-          // div.setAttribute( 'timeline-date', cleanedEndDate )
-          // div.setAttribute( 'timeline-date', end )
         }
       )
 
@@ -228,33 +221,9 @@ export async function buildVerticalTimeline(
       }
     }
 
-    /* If the previous note is of class 'timeline-tail' then there's a chance that the current node belongs nested within
-       the previous one. Here we iterate backwards for as long as elements of the class 'timeline-tail' are encountered.
-
-       Then we sort an array containing the start and ending date of the current event along with the ending date of the
-       previous event. If the index of the ending date of the previous event in the new array is greater than 0 then the
-       note(s) preceding it (either the note belonging to the start date or the notes belonging to both the start and end
-       dates of the current event) are placed before their predecessor. */
-    for ( let i = noteDivs.length - 2; i >= 0; i-- ) {
-      if ( noteDivs[i].classList.contains( 'timeline-tail' )) {
-        const t = noteDivs[i].getAttribute( 'timeline-date' )
-        const times = [t, ...noteDivs.map(( n ) => {
-          return n.getAttribute( 'timeline-date' ) 
-        })].sort()
-        const lastTIndex = times.lastIndexOf( t )
-
-        for ( let j = lastTIndex; j > 0; j = 0 ) {
-          noteDivs[i].before( ...noteDivs.slice( 0, j ))
-          const indent = +noteDivs[0].style.getPropertyValue( '--timeline-indent' ) + 1
-          noteDivs.forEach(( n ) => {
-            return n.style.setProperty( '--timeline-indent', `${indent}` ) 
-          })
-        }
-      }
-    }
+    sortAndRenderNestedEvents( noteDivs, timeline )
 
     eventCount++
-    console.log({ datedTo })
   }
 
   // Replace the selected tags with the timeline html

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,6 +101,16 @@ export interface InternalTimelineArgs {
   zoomOutLimit: number,
 }
 
+export interface MinimizedResult {
+  readable: string,
+  cleaned: string,
+  normalized: string,
+}
+
+export interface NormalizeAndCleanDateOutput extends CleanedDateResultObject {
+  normalizedDate: string
+}
+
 export interface TimelinesSettings {
   eventElement: AcceptableEventElements,
   frontMatterKeys: FrontMatterKeys,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { FrontMatterCache, MetadataCache, TFile, Vault } from 'obsidian'
+import { DataItem } from 'vis-timeline'
 
 /* ------------------------------ */
 /*              Enums             */
@@ -54,7 +55,7 @@ export interface EventItem {
   id: number,
   className: string,
   content: string,
-  end: Date,
+  end: Date | undefined,
   path: string,
   start: Date,
   type: string,
@@ -115,5 +116,6 @@ export interface TimelinesSettings {
 /* ------------------------------ */
 
 export type AllNotesData = ( CardContainer[] )[]
+export type CombinedTimelineEventData = EventItem & DataItem
 export type DivWithCalcFunc = HTMLDivElement & { calcLength?: () => void }
 export type EventCountData = ( HTMLElement | FrontMatterCache | null )[]

--- a/src/utils/arguments.ts
+++ b/src/utils/arguments.ts
@@ -6,10 +6,10 @@ export function setDefaultArgs(): InternalTimelineArgs {
   return {
     tags: [] as string[],
     divHeight: 400,
-    startDate: buildTimelineDate( '-1000' ),
-    endDate: buildTimelineDate( '3000' ),
-    minDate: buildTimelineDate( '-3000' ),
-    maxDate: buildTimelineDate( '3000' ),
+    startDate: buildTimelineDate( '-1000' )!,
+    endDate: buildTimelineDate( '3000' )!,
+    minDate: buildTimelineDate( '-3000' )!,
+    maxDate: buildTimelineDate( '3000' )!,
     type: null,
 
     // have to put it to one more than the default max so that min actually works

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -53,15 +53,10 @@ const minimizeDateString = ( dateString: string ): string => {
   }
 
   if ( !sections.length ) {
-    throw new Error( 'idk man' )
+    throw new Error( 'could not get the different sections of the event date' )
   }
 
-  // 0 is year
-  // 1 is month
-  // 2 is day
-  // 3 is hour
-
-  console.log( 'before', { sections })
+  logger( 'minimizeDateString | before', { sections })
 
   // we always at least have the year
   const remainingSections: string[] = [ (( isNegative ? '-' : '' ) + sections[0] ) ]
@@ -79,7 +74,7 @@ const minimizeDateString = ( dateString: string ): string => {
     remainingSections.push( sections[i] )
   }
 
-  console.log( 'remaining', { remainingSections })
+  logger( 'minimizeDateString | remaining', { remainingSections })
 
   return remainingSections.join( '-' )
 }

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -27,7 +27,10 @@ const makeSureDateSectionIsNotZero = ( section: string, sectionValue: number, de
  * 
  * @returns {CleanedDateResultObject}
  */
-export const cleanDate = ( normalizedDate: string ): CleanedDateResultObject => {
+export const cleanDate = ( normalizedDate: string ): CleanedDateResultObject | null => {
+  if ( normalizedDate === null ) {
+    return null
+  }
   const isNegative = normalizedDate[0] === '-'
   const parts = normalizedDate.slice( 1 ).split( '-' )
 

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -2,17 +2,7 @@ import { DateTime } from 'luxon'
 
 import { logger } from './debug'
 import { DEFAULT_SETTINGS } from '../constants'
-import { CleanedDateResultObject } from '../types'
-
-interface MinimizedResult {
-  readable: string,
-  cleaned: string,
-  normalized: string,
-}
-
-interface NormalizeAndCleanDateOutput extends CleanedDateResultObject {
-  normalizedDate: string
-}
+import { CleanedDateResultObject, MinimizedResult, NormalizeAndCleanDateOutput } from '../types'
 
 export const buildMinimizedDateString = ( str: string ): MinimizedResult => {
   const normalizedAndCleaned = normalizeAndCleanDate( str )
@@ -67,6 +57,7 @@ const minimizeDateString = ( dateString: string ): string => {
     }
 
     // if we're looking at hour but day is not set, skip
+    // todo: if hour is not set, but day is, don't show it
     if ( i === 3 && parseInt( sections[i - 1] ) < 1 ) {
       continue
     }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -32,12 +32,16 @@ export function filterMDFiles( file: TFile, tagList: string[], metadataCache: Me
     return true
   }
 
-  const rawTags = getAllTags( metadataCache.getFileCache( file ))
+  const cache = metadataCache.getFileCache( file )
+  if ( !cache ) {
+    throw new Error( "Failed to get the file's metadataCache" )
+  }
+  const rawTags = getAllTags( cache )
   logger( `filterMDFiles | rawTags from file: ${file.name}:`, rawTags )
 
-  const tags = rawTags.map(( e ) => {
+  const tags = rawTags?.map(( e ) => {
     return e.slice( 1 )
-  })
+  }) ?? []
   logger( `filterMDFiles | getAllTags from file: ${file.name}:`, tags )
 
   if ( !tags.length ) {
@@ -65,7 +69,7 @@ export function filterMDFiles( file: TFile, tagList: string[], metadataCache: Me
  */
 export function getImgUrl( vault: Vault, path: string ): string {
   if ( !path ) {
-    return null
+    return ''
   }
 
   if ( path.includes( 'https://' )) {
@@ -76,6 +80,8 @@ export function getImgUrl( vault: Vault, path: string ): string {
   if ( file instanceof TFile ) {
     return vault.getResourcePath( file )
   }
+
+  return ''
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "module": "ESNext",
     "moduleResolution": "node",
     // "noImplicitAny": true,
+    "strictNullChecks": true,
     "target": "es6",
   },
   "include": [


### PR DESCRIPTION
### v2.2.7

Bug fix for issue: `"YYYY" Format` [#81](https://github.com/seanlowe/obsidian-timelines/issues/81)

**Changes:**
- implemented some logic to determine what sections of the provided dates are missing originally and to not display a cleaned version of the normalized date but a "readable" date that should closer match what the user provides in the event.
- tweaked some logic in the nesting / sorting functionality on the vertical timeline. Events now sort the start and end of time ranges correctly (so far as I can tell).

---

Resolves #81 