### PR TITLE
Bug Fix for: `[Bug - Vertical] Sections of the date are visible when not provided`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,14 @@ You can check out the docs for **Timelines (Revamped)** [here](https://seanlowe.
 
 ## Release Notes
 
-### v2.3.1
+### v2.3.2
 
-Small QoL changes
+Bug Fix for: `[Bug - Vertical] Sections of the date are visible when not provided` [#86](https://github.com/seanlowe/obsidian-timelines/issues/86)
 
 **Changes:**
-- update some logging across the render workflow
-- small change to validity check on start and end dates on horizontal timelines
-- rearrange some functions in `dates.ts`
-- small updates to the README and the docs
+- revamped the date functionality so that users can pass date string sections as 0 or choose not pass them at all to keep them from rendering on the timeline
+- removed some unnecessary functions and types in cleanup
+- updated the docs on HTML event arguments to portray the new functionality
 
 See the [changelog](./changelog.md) for more details on previous releases.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,15 @@
 ## Changelog
 
+### v2.3.1
+
+Small QoL changes
+
+**Changes:**
+- update some logging across the render workflow
+- small change to validity check on start and end dates on horizontal timelines
+- rearrange some functions in `dates.ts`
+- small updates to the README and the docs
+
 ### v2.3.0
 
 Implement issue: `Multi-Type Timelines` [#43](https://github.com/seanlowe/obsidian-timelines/issues/43)

--- a/docs/content/docs/03_arguments/01_html_arguments.md
+++ b/docs/content/docs/03_arguments/01_html_arguments.md
@@ -27,7 +27,7 @@ Any included Month/Day sections of a date must be non-zero (for the time being) 
 
 For example: `2300-02-00-00` **should be passed as**: `2300-02` if you don't care about the day, or `2300-02-01` if you mean that it began at the beginning of the month. The last section of a date (the time), however, can be zero if you want. Any section that is not passed in will be added internally with the valid minimal value (`01`)
 
-> **NOTE:** Passing DAY and HOUR values as `0` will break your timeline. There's not much I can do about this on my end without a substantial rewrite of the dates systems. Perhaps one day I will tackle that.
+> **NOTE:** For values you don't want rendered, you can *either* pass those values as `0` or you can omit them from your event's date string. 
 
 Date normalization is handled according to the next section **Event Sorting**, so that dates -- even fantasy ones -- are sorted in the order specified. Although, there are some ... *intricacies*, when dealing with odd fantasy dates with the horizontal timeline simply due to the library used to generate the timeline. I'm looking into better solutions for this.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "timelines-revamped",
   "name": "Timelines (Revamped)",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "minAppVersion": "0.10.11",
   "description": "Successor to darakah's Timelines plugin: Generate a chronological timeline in which all 'events' are notes that include a specific tag or set of tags.",
   "author": "seanlowe",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "timelines-revamped",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "timelines-revamped",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "MIT",
       "dependencies": {
         "chroma-js": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timelines-revamped",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Generate a chronological timeline in which all 'events' are notes that include a specific tag or set of tags.",
   "main": "main.js",
   "scripts": {

--- a/src/block.ts
+++ b/src/block.ts
@@ -21,7 +21,6 @@ import {
   getNumEventsInFile,
   isHTMLElementType,
   logger,
-  normalizeDate,
   setDefaultArgs,
   sortTimelineDates,
 } from './utils'
@@ -181,51 +180,33 @@ export class TimelineBlockProcessor {
           }
         }
 
-        // check if a valid date is specified
-        const noteId = normalizeDate( startDate, parseInt( this.settings.maxDigits ))
-        logger( 'parseFiles | noteId', noteId )
-
         const imgUrl = getImgUrl( this.appVault, eventImg )
+        const maxDigits = parseInt( this.settings.maxDigits )
+        const cleanedStartDateObject = cleanDate( startDate, maxDigits )
+        const cleanedEndDateObject   = cleanDate( endDate, maxDigits )
 
-        // normalizedStartDate is the same as noteId
-        let normalizedEndDate   = normalizeDate(  endDate  )
+        if ( !cleanedStartDateObject || !cleanedEndDateObject ) {
+          throw new Error( 'either the start or end date object is missing' )
+        }
 
+        const { normalizedDateString: noteId } = cleanedStartDateObject
         if ( !noteId ) {
           console.error( "Cannot normalize the event's start date! Skipping" ) 
           return
         }
 
-        if ( !normalizedEndDate ) {
-          console.warn( "parseFiles | Couldn't normalize the event's end date, setting it to empty." )
-          normalizedEndDate = ''
-        }
-
-        const cleanedStartDateObject = cleanDate( noteId )
-        const cleanedEndDateObject   = cleanDate( normalizedEndDate )
-
-        if ( !cleanedStartDateObject ) {
-          const message = 'no start date object'
-          throw new Error( message )
-        }
-
-        if ( !cleanedEndDateObject ) {
-          const message = 'no end date object'
-          throw new Error( message )
-        }
-
-        const { cleanedDateString: cleanedStartDate } = cleanedStartDateObject
-        const { cleanedDateString:  cleanedEndDate  } = cleanedEndDateObject
+        logger( 'parseFiles | noteId', noteId )
 
         const note: CardContainer = {
           id: noteId,
           classes,
           color,
-          endDate: cleanedEndDate,
+          endDate: cleanedEndDateObject,
           era,
           img: imgUrl,
           body: noteBody,
           path: notePath,
-          startDate: cleanedStartDate,
+          startDate: cleanedStartDateObject,
           title: noteTitle,
           type,
         }

--- a/src/timelines/horizontal.ts
+++ b/src/timelines/horizontal.ts
@@ -62,7 +62,7 @@ export async function buildHorizontalTimeline(
       let type: string = event.type
       let typeOverride = false
       let end: Date | null = null
-      const start = buildTimelineDate( event.startDate, parseInt( settings.maxDigits ))
+      const start = buildTimelineDate( event.startDate.normalizedDateString, parseInt( settings.maxDigits ))
       if ( !start ) {
         console.warn(
           "buildHorizontalTimeline | Couldn't build the starting timeline date for the horizontal timeline",
@@ -72,9 +72,9 @@ export async function buildHorizontalTimeline(
         return
       }
 
-      if ( event.endDate && event.endDate !== '' ) {
+      if ( event.endDate.normalizedDateString && event.endDate.normalizedDateString !== '' ) {
         logger( 'buildHorizontalTimeline | there is an endDate for event:', event )
-        end = buildTimelineDate( event.endDate, parseInt( settings.maxDigits ))
+        end = buildTimelineDate( event.endDate.normalizedDateString, parseInt( settings.maxDigits ))
       } else {
         // if there is no end date, we cannot render as anything other than 'point'
         logger( 'buildHorizontalTimeline | NO endDate for event:', event )

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,13 @@ export enum AcceptableEventElements {
 /* ------------------------------ */
 
 export interface CleanedDateResultObject {
+  // full items
   cleanedDateString: string,
+  minimizedDateString: string,
+  normalizedDateString: string,
+  originalDateString: string,
+
+  // parts
   day: number,
   hour: number,
   month: number,
@@ -27,11 +33,11 @@ export interface CardContainer {
   body: string,
   classes: string,
   color: string,
-  endDate: string,
+  endDate: CleanedDateResultObject,
   era: string,
   img: string,
   path: string,
-  startDate: string,
+  startDate: CleanedDateResultObject,
   title: string,
   type: string,
 }
@@ -59,7 +65,7 @@ export interface EventItem {
   path: string,
   start: Date,
   type: string,
-  _event?: Partial<EventDataObject>,
+  _event?: Partial<CardContainer>,
 }
 
 export interface EventTypeNumbers {
@@ -99,16 +105,6 @@ export interface InternalTimelineArgs {
   type: string | null,
   zoomInLimit: number,
   zoomOutLimit: number,
-}
-
-export interface MinimizedResult {
-  readable: string,
-  cleaned: string,
-  normalized: string,
-}
-
-export interface NormalizeAndCleanDateOutput extends CleanedDateResultObject {
-  normalizedDate: string
 }
 
 export interface ParsedTagObject {


### PR DESCRIPTION
### v2.3.2

Bug Fix for: `[Bug - Vertical] Sections of the date are visible when not provided` [#86](https://github.com/seanlowe/obsidian-timelines/issues/86)

**Changes:**
- revamped the date functionality so that users can pass date string sections as 0 or choose not pass them at all to keep them from rendering on the timeline
- removed some unnecessary functions and types in cleanup
- updated the docs on HTML event arguments to portray the new functionality

---

Resolves #86 